### PR TITLE
#95 - removed the dep on the 6.2 version of reporting-common

### DIFF
--- a/Source/Plugins/Server/com.tle.core.reporting/build.sbt
+++ b/Source/Plugins/Server/com.tle.core.reporting/build.sbt
@@ -5,7 +5,7 @@ libraryDependencies ++= Seq(
   "rhino" % "js" % "1.7R2",
   "org.eclipse.birt" % "birt-api" % "3.7.2",
   "org.eclipse.birt.runtime" % "org.eclipse.datatools.connectivity.oda" % "3.3.3.v201110130935",
-  "com.tle.reporting" % "reporting-common-6.2" % "2"
+  "com.tle.reporting" % "reporting-common-6.3" % "0.20141006"
 ).map(_ % Birt)
 
 ivyConfigurations := overrideConfigs(Birt, CustomCompile)(ivyConfigurations.value)


### PR DESCRIPTION
Tested on a fresh build env / equella-deps without the reporting-common 6.2 dep and it appeared to work fine.