### PR TITLE
98. To remove office dll from code we just point to the documentation instead to the msi file

### DIFF
--- a/Source/Plugins/Server/com.tle.web.mycontent.files/resources/lang/i18n.properties
+++ b/Source/Plugins/Server/com.tle.web.mycontent.files/resources/lang/i18n.properties
@@ -32,7 +32,8 @@ breadcrumb.link.scrapbook = Scrapbook
 receipt.bulkuploads = {0} files have been successfully uploaded into your scrapbook
 
 label.downloads = Downloads
-label.download.officeintegration = EQUELLA Office Scrapbook Integration (Windows only)
+label.information = Information
+label.download.officeintegration = Information about the EQUELLA Office Scrapbook Integration (Windows only).
 
 inplace.link.editfilewith = Edit file with...
 inplace.link.editfile = Edit file

--- a/Source/Plugins/Server/com.tle.web.mycontent.files/src/com/tle/web/myresource/MyResourceContributeSection.java
+++ b/Source/Plugins/Server/com.tle.web.mycontent.files/src/com/tle/web/myresource/MyResourceContributeSection.java
@@ -70,7 +70,6 @@ import com.tle.web.sections.annotations.Bookmarked;
 import com.tle.web.sections.annotations.EventFactory;
 import com.tle.web.sections.annotations.EventHandlerMethod;
 import com.tle.web.sections.equella.annotation.PlugKey;
-import com.tle.web.sections.equella.annotation.PlugURL;
 import com.tle.web.sections.equella.receipt.ReceiptService;
 import com.tle.web.sections.events.RenderContext;
 import com.tle.web.sections.events.RenderEventContext;
@@ -138,8 +137,7 @@ public class MyResourceContributeSection extends AbstractPrototypeSection<MyReso
 	private static final PluginResourceHelper URL_HELPER = ResourcesService
 		.getResourceHelper(MyResourceContributeSection.class);
 
-	@PlugURL("downloads/EquellaOfficeIntegrationInstaller.msi")
-	private static String DOWNLOAD_OFFICE_INTEG_URL;
+	private static String DOWNLOAD_OFFICE_INTEG_URL="https://equella.github.io/";
 
 	@PlugKey("dnd.upload")
 	private static String STRING_UPLOAD;
@@ -168,6 +166,8 @@ public class MyResourceContributeSection extends AbstractPrototypeSection<MyReso
 	private static Label LABEL_REPLACE_FILE;
 	@PlugKey("label.downloads")
 	private static Label LABEL_DOWNLOADS;
+    @PlugKey("label.information")
+    private static Label LABEL_INFORMATION;
 
 	@Inject
 	private ConfigurationService configService;
@@ -683,7 +683,8 @@ public class MyResourceContributeSection extends AbstractPrototypeSection<MyReso
 		final HtmlLinkState downloadOfficeIntegrationLink = new HtmlLinkState();
 		downloadOfficeIntegrationLink.setBookmark(new SimpleBookmark(DOWNLOAD_OFFICE_INTEG_URL));
 		downloadOfficeIntegrationLink.setLabel(LABEL_DOWNLOAD_OFFICE_INTEGRATION);
-		event.addTab(new BlueBarRenderable("downloads", LABEL_DOWNLOADS, viewFactory.createResultWithModel(
+		downloadOfficeIntegrationLink.setTarget("_blank");
+		event.addTab(new BlueBarRenderable("downloads", LABEL_INFORMATION, viewFactory.createResultWithModel(
 			"downloads.ftl", downloadOfficeIntegrationLink), 50));
 	}
 


### PR DESCRIPTION
As the office.dll has not a compatible license we should remove it. If we do so, we can't build the msi file. The solution will be to provide instructions about how to build the msi file for the office integration to anyone that have the license to do it. this PR change the link to download the msi file to a link to the documentation. 