### PR TITLE
#269 Shuffle controls special chars

### DIFF
--- a/Source/Plugins/Controls/com.tle.web.wizard.controls/resources/web/js/dialog/controls.js
+++ b/Source/Plugins/Controls/com.tle.web.wizard.controls/resources/web/js/dialog/controls.js
@@ -12,9 +12,9 @@ function getValues(multi)
 		}
 		if (i > 0)
 		{
-			fullvalue += "|";
+			fullvalue += "⛐";
 		}
-		fullvalue += escape(Utf8.encode(value));
+		fullvalue += encodeURIComponent(value);
 	}
 
 	return fullvalue;
@@ -24,10 +24,10 @@ function setValues(multi, valuesStr)
 {
 	var controls = multi.controls;
 	var ncont = controls.length;
-	var values = valuesStr.split("|");
+	var values = valuesStr.split("⛐");
 	for ( var i = 0; i < ncont; i++)
 	{
-		controls[i].edit(unescape(Utf8.decode(values[i])));
+		controls[i].edit(decodeURIComponent(values[i]));
 	}
 }
 

--- a/Source/Plugins/Controls/com.tle.web.wizard.controls/resources/web/js/shufflelist.js
+++ b/Source/Plugins/Controls/com.tle.web.wizard.controls/resources/web/js/shufflelist.js
@@ -32,7 +32,7 @@
 					if(addListItem(value))
 					{
 						control.val('');
-						addOption(multi.list, value, value);
+						addOption(multi.list, value, encodeURIComponent(value));
 					}
 				}
 				else

--- a/Source/Plugins/Server/com.tle.web.wizard/src/com/tle/web/wizard/controls/CMultiCtrl.java
+++ b/Source/Plugins/Server/com.tle.web.wizard/src/com/tle/web/wizard/controls/CMultiCtrl.java
@@ -39,8 +39,11 @@ public class CMultiCtrl extends MultipleCtrl
 {
 	private static final long serialVersionUID = 1L;
 
+	private static final String VALUE_SEP = "⛐"; // Unicode 26D0
+	private static final String NAME_SEP = " / ";
+
 	protected List<NameValue> namesValues = new ArrayList<NameValue>();
-	private String separator = " / "; //$NON-NLS-1$
+	private String separator = NAME_SEP;
 
 	public CMultiCtrl(WizardPage page, int controlNumber, int nestingLevel, WizardControl controlBean)
 		throws WizardPageException
@@ -91,7 +94,7 @@ public class CMultiCtrl extends MultipleCtrl
 				if( !first )
 				{
 					sbufName.append(separator);
-					sbufValue.append('|');
+					sbufValue.append(VALUE_SEP);
 				}
 				else
 				{
@@ -129,7 +132,7 @@ public class CMultiCtrl extends MultipleCtrl
 				sbufName.setLength(0);
 				sbufValue.setLength(0);
 				boolean first = true;
-				String[] colvals = element.split("\\|", -1); //$NON-NLS-1$
+				String[] colvals = element.split(VALUE_SEP, -1); //$NON-NLS-1$
 				for( int j = 0; j < colvals.length; j++ )
 				{
 					HTMLControl ctrl = controls.get(j);
@@ -140,7 +143,7 @@ public class CMultiCtrl extends MultipleCtrl
 					if( !first )
 					{
 						sbufName.append(separator);
-						sbufValue.append('|');
+						sbufValue.append(VALUE_SEP);
 					}
 					else
 					{
@@ -161,7 +164,7 @@ public class CMultiCtrl extends MultipleCtrl
 
 		for( NameValue nameValue : namesValues )
 		{
-			String[] colvals = nameValue.getValue().split("\\|", -1); //$NON-NLS-1$
+			String[] colvals = nameValue.getValue().split(VALUE_SEP, -1); //$NON-NLS-1$
 			for( int j = 0; j < colvals.length; j++ )
 			{
 				HTMLControl ctrl = controls.get(j);


### PR DESCRIPTION
You can now enter pipes and percent characters in shuffle list and shuffle group controls.

The new delimiter is a "slippery when wet car" character, which has the added bonus that because it's unicode it won't even conflict with user-entered slippery when wet cars (it could happen...) since they are URL encoded in the JS.

Note that before this fix (and not noted in the original bug description), you could not enter unicode characters into the shuffle group controls and have them persisted properly.