### PR TITLE
Issue 229:  Use a wildcard search for the ItemMetadataFilter

### DIFF
--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/reindex/ItemMetadataFilter.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/reindex/ItemMetadataFilter.java
@@ -16,11 +16,17 @@
 
 package com.tle.core.freetext.reindex;
 
+import java.util.Arrays;
+
+import org.apache.log4j.Logger;
+
 /**
  * @author Nicholas Read
  */
 public class ItemMetadataFilter extends ReindexFilter
 {
+	private static final Logger LOGGER = Logger.getLogger(ItemMetadataFilter.class);
+
 	private static final long serialVersionUID = 1L;
 
 	private static final String[] NAMES = {"targetId"};
@@ -35,7 +41,7 @@ public class ItemMetadataFilter extends ReindexFilter
 	@Override
 	protected String getWhereClause()
 	{
-		return "where :targetId in (metadataSecurityTargets)";
+		return "where metadataSecurityTargets like :targetId";
 	}
 
 	@Override
@@ -47,6 +53,12 @@ public class ItemMetadataFilter extends ReindexFilter
 	@Override
 	protected Object[] getValues()
 	{
-		return values;
+		// Bookend the target ID(s) with wildcards for the 'like' where clause.
+		Object[] ret = Arrays.stream(values).map(s -> "%" + s + "%").toArray();
+		if(LOGGER.isTraceEnabled()) {
+			LOGGER.trace("Original values: " + Arrays.toString(values));
+			LOGGER.trace("Wildcard values: " + Arrays.toString(ret));
+		}
+		return ret;
 	}
 }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/item/dao/impl/ItemDaoImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/item/dao/impl/ItemDaoImpl.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import org.apache.log4j.Logger;
 import org.hibernate.HibernateException;
 import org.hibernate.Query;
 import org.hibernate.Session;
@@ -86,6 +87,8 @@ import com.tle.core.plugins.PluginTracker;
 @SuppressWarnings({"nls", "unchecked"})
 public class ItemDaoImpl extends GenericInstitionalDaoImpl<Item, Long> implements ItemDao
 {
+	private static final Logger LOGGER = Logger.getLogger(ItemDaoImpl.class);
+
 	@Inject
 	private ItemLockingDao itemLockingDao;
 
@@ -575,12 +578,15 @@ public class ItemDaoImpl extends GenericInstitionalDaoImpl<Item, Long> implement
 				for( String name : names )
 				{
 					Object obj = values[i++];
+					LOGGER.trace("Inspecting parameter [" + name + "] with obj of type [" + obj.getClass().getName() + "].");
 					if( obj instanceof Collection )
 					{
+						LOGGER.trace("Setting parameter list [" + name + "].");
 						query.setParameterList(name, (Collection<?>) obj);
 					}
 					else
 					{
+						LOGGER.trace("Setting parameter [" + name + "] to [" + obj + "].");
 						query.setParameter(name, obj);
 					}
 				}

--- a/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/dao/helpers/DMLPartitioner.java
+++ b/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/dao/helpers/DMLPartitioner.java
@@ -16,6 +16,7 @@
 
 package com.tle.core.dao.helpers;
 
+import org.apache.log4j.Logger;
 import org.hibernate.HibernateException;
 import org.hibernate.Query;
 import org.hibernate.ScrollableResults;
@@ -30,6 +31,8 @@ import org.springframework.orm.hibernate3.HibernateCallback;
 @SuppressWarnings("nls")
 public abstract class DMLPartitioner implements HibernateCallback
 {
+	private static final Logger LOGGER = Logger.getLogger(DMLPartitioner.class);
+
 	private static final int MAX_BATCH_SIZE = 500;
 
 	private final String tableName;


### PR DESCRIPTION
Resolution to https://github.com/equella/Equella/issues/229 : Resources will not be re-indexed when editing Resource Metadata ACLs in the Collection Definition Editor in the Administration Console

I still need to do some final testing on this, but looks to work on initial tests with Postgres so I wanted to get the basic idea of the fix out here for folks to review.