### PR TITLE
ci(travis): test open and oracle jdk, test multiple scala versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,19 @@ cache:
   - "$HOME/.ivy2"
 jdk:
 - oraclejdk8
+- openjdk8
+scala:
+- 2.9.3
+- 2.10.7
+- 2.11.12
+- 2.12.4
 before_install:
 - sudo apt-get install awscli
 - yarn global add browserify
 install:
 - git fetch --unshallow
 script:
-- sbt headerCheck test installerZip writeLanguagePack
+- sbt ++$TRAVIS_SCALA_VERSION headerCheck test installerZip writeLanguagePack
 after_success:
 - aws s3 --region us-east-1 cp Source/Server/equellaserver/target/tle-upgrade*.zip s3://edalexdev/equella_artifacts/$TRAVIS_BRANCH/$TRAVIS_BUILD_NUMBER/
 - aws s3 --region us-east-1 cp Installer/target/equella-installer*.zip s3://edalexdev/equella_artifacts/$TRAVIS_BRANCH/$TRAVIS_BUILD_NUMBER/


### PR DESCRIPTION
Adding Open JDK and multiple Scala versions to the test matrix allows for gives assurances in terms of language support.
Without adding too much testing burden, Travis CI does the heavy lifting, tests run in parallel 5 at a time.