### PR TITLE
#492 Parse duration cap implemented for PDFs

### DIFF
--- a/Source/Plugins/Core/com.equella.base/src/com/tle/core/TextExtracterExtension.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/core/TextExtracterExtension.java
@@ -26,7 +26,7 @@ import com.tle.beans.mime.MimeEntry;
  */
 public interface TextExtracterExtension
 {
-	void extractText(String mimeType, InputStream input, StringBuilder outputText, int maxSize, long parseDurationCap, int durationCheckFrequency) throws IOException;
+	void extractText(String mimeType, InputStream input, StringBuilder outputText, int maxSize, long parseDurationCap) throws IOException;
 
 	void setEnabledForMimeEntry(MimeEntry mimeType, boolean enabled);
 

--- a/Source/Plugins/Core/com.equella.base/src/com/tle/core/TextExtracterExtension.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/core/TextExtracterExtension.java
@@ -26,7 +26,7 @@ import com.tle.beans.mime.MimeEntry;
  */
 public interface TextExtracterExtension
 {
-	void extractText(String mimeType, InputStream input, StringBuilder outputText, int maxSize) throws IOException;
+	void extractText(String mimeType, InputStream input, StringBuilder outputText, int maxSize, long parseDurationCap, int durationCheckFrequency) throws IOException;
 
 	void setEnabledForMimeEntry(MimeEntry mimeType, boolean enabled);
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/extracter/handler/CappedBodyContentHandler.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/extracter/handler/CappedBodyContentHandler.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017 Apereo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tle.core.freetext.extracter.handler;
+
+import org.apache.tika.sax.BodyContentHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.SAXException;
+
+public class CappedBodyContentHandler extends BodyContentHandler {
+	private long parseDurationCap = Long.MAX_VALUE;
+
+	private long start = 0L;
+
+	private int durationCheckCounter = 0;
+
+	private int durationCheckFrequency = Integer.MAX_VALUE;
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(CappedBodyContentHandler.class);
+
+	public CappedBodyContentHandler(ContentHandler handler, long parseDurationCap, int durationCheckFrequency) {
+		super(handler);
+		this.parseDurationCap = parseDurationCap;
+		this.durationCheckFrequency = durationCheckFrequency;
+	}
+
+	@Override
+	public void startDocument() throws SAXException {
+		LOGGER.debug("Beginning startDocument of parse with a durationCheckFrequencyk=[" + durationCheckFrequency + "] and parseDurationCap=[" + parseDurationCap + "].");
+		start = System.currentTimeMillis();
+		super.startDocument();
+	}
+
+	@Override
+	public void characters(char[] ch, int start, int length)
+			throws SAXException {
+		checkIfOverCappedDuration();
+		super.characters(ch, start, length);
+	}
+
+	@Override
+	public void ignorableWhitespace(char[] ch, int start, int length)
+			throws SAXException {
+		checkIfOverCappedDuration();
+		super.ignorableWhitespace(ch, start, length);
+	}
+
+	@Override
+	public void skippedEntity(String name) throws SAXException {
+		checkIfOverCappedDuration();
+		super.skippedEntity(name);
+	}
+
+	private void checkIfOverCappedDuration() throws SAXException{
+		if(durationCheckCounter++ > durationCheckFrequency) {
+			long dur = System.currentTimeMillis() - start;
+			LOGGER.debug("Checking if parser is past capped duration - time spent so far: " + dur);
+			if(parseDurationCap < dur) {
+				throw new SAXException("Parser exceeding maximum duration of parse max="+parseDurationCap);
+			} else {
+				durationCheckCounter = 0;
+			}
+		}
+	}
+}

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/extracter/handler/CappedBodyContentHandler.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/extracter/handler/CappedBodyContentHandler.java
@@ -23,25 +23,24 @@ import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 
 public class CappedBodyContentHandler extends BodyContentHandler {
-	private long parseDurationCap = Long.MAX_VALUE;
+	private long parseDurationCap;
 
 	private long start = 0L;
 
 	private int durationCheckCounter = 0;
 
-	private int durationCheckFrequency = Integer.MAX_VALUE;
+	private static final int DURATION_CHECK_FREQUENCY = 200;
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(CappedBodyContentHandler.class);
 
-	public CappedBodyContentHandler(ContentHandler handler, long parseDurationCap, int durationCheckFrequency) {
+	public CappedBodyContentHandler(ContentHandler handler, long parseDurationCap) {
 		super(handler);
 		this.parseDurationCap = parseDurationCap;
-		this.durationCheckFrequency = durationCheckFrequency;
 	}
 
 	@Override
 	public void startDocument() throws SAXException {
-		LOGGER.debug("Beginning startDocument of parse with a durationCheckFrequencyk=[" + durationCheckFrequency + "] and parseDurationCap=[" + parseDurationCap + "].");
+		LOGGER.debug("Beginning startDocument of parse with a parseDurationCap=[" + parseDurationCap + "].");
 		start = System.currentTimeMillis();
 		super.startDocument();
 	}
@@ -67,11 +66,11 @@ public class CappedBodyContentHandler extends BodyContentHandler {
 	}
 
 	private void checkIfOverCappedDuration() throws SAXException{
-		if(durationCheckCounter++ > durationCheckFrequency) {
+		if(durationCheckCounter++ > DURATION_CHECK_FREQUENCY) {
 			long dur = System.currentTimeMillis() - start;
 			LOGGER.debug("Checking if parser is past capped duration - time spent so far: " + dur);
 			if(parseDurationCap < dur) {
-				throw new SAXException("Parser exceeding maximum duration of parse max="+parseDurationCap);
+				throw new SAXException("Parser exceeded maximum duration of parse.  max="+parseDurationCap);
 			} else {
 				durationCheckCounter = 0;
 			}

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/extracter/standard/AbstractOffice2007Extracter.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/extracter/standard/AbstractOffice2007Extracter.java
@@ -43,9 +43,10 @@ public abstract class AbstractOffice2007Extracter extends AbstractTextExtracterE
 	public abstract String getNameOfElementToIndex();
 
 	@Override
-	public void extractText(String mimeType, InputStream input, StringBuilder outputText, int maxSize)
+	public void extractText(String mimeType, InputStream input, StringBuilder outputText, int maxSize, long parseDuration, int durationCheckFrequency)
 		throws IOException
 	{
+		// Ignore parseDuration and durationCheckFrequency for now.
 		try
 		{
 			ArchiveExtractor extractor = ArchiveType.ZIP.createExtractor(input);

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/extracter/standard/AbstractOffice2007Extracter.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/extracter/standard/AbstractOffice2007Extracter.java
@@ -43,10 +43,10 @@ public abstract class AbstractOffice2007Extracter extends AbstractTextExtracterE
 	public abstract String getNameOfElementToIndex();
 
 	@Override
-	public void extractText(String mimeType, InputStream input, StringBuilder outputText, int maxSize, long parseDuration, int durationCheckFrequency)
+	public void extractText(String mimeType, InputStream input, StringBuilder outputText, int maxSize, long parseDuration)
 		throws IOException
 	{
-		// Ignore parseDuration and durationCheckFrequency for now.
+		// Ignore parseDuration for now.
 		try
 		{
 			ArchiveExtractor extractor = ArchiveType.ZIP.createExtractor(input);

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/extracter/standard/HtmlExtracter.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/extracter/standard/HtmlExtracter.java
@@ -44,9 +44,10 @@ public class HtmlExtracter extends AbstractTextExtracterExtension
 	}
 
 	@Override
-	public void extractText(String mimeType, InputStream input, StringBuilder outputText, int maxSize)
+	public void extractText(String mimeType, InputStream input, StringBuilder outputText, int maxSize, long parseDuration, int durationCheckFrequency)
 		throws IOException
 	{
+		// Ignore parseDuration and durationCheckFrequency for now.
 		String summary = new HTMLFilter(input).getSummary(maxSize);
 		outputText.append(summary);
 		if( LOGGER.isDebugEnabled() )

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/extracter/standard/HtmlExtracter.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/extracter/standard/HtmlExtracter.java
@@ -44,10 +44,10 @@ public class HtmlExtracter extends AbstractTextExtracterExtension
 	}
 
 	@Override
-	public void extractText(String mimeType, InputStream input, StringBuilder outputText, int maxSize, long parseDuration, int durationCheckFrequency)
+	public void extractText(String mimeType, InputStream input, StringBuilder outputText, int maxSize, long parseDuration)
 		throws IOException
 	{
-		// Ignore parseDuration and durationCheckFrequency for now.
+		// Ignore parseDuration for now.
 		String summary = new HTMLFilter(input).getSummary(maxSize);
 		outputText.append(summary);
 		if( LOGGER.isDebugEnabled() )

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/extracter/standard/MsExcelExtracter.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/extracter/standard/MsExcelExtracter.java
@@ -48,10 +48,10 @@ public class MsExcelExtracter extends AbstractTextExtracterExtension
 	}
 
 	@Override
-	public void extractText(String mimeType, InputStream input, StringBuilder outputText, int maxSize)
+	public void extractText(String mimeType, InputStream input, StringBuilder outputText, int maxSize, long parseDuration, int durationCheckFrequency)
 		throws IOException
 	{
-
+		// Ignore parseDuration and durationCheckFrequency for now.
 		try
 		{
 			Metadata meta = new Metadata();

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/extracter/standard/MsExcelExtracter.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/extracter/standard/MsExcelExtracter.java
@@ -48,10 +48,10 @@ public class MsExcelExtracter extends AbstractTextExtracterExtension
 	}
 
 	@Override
-	public void extractText(String mimeType, InputStream input, StringBuilder outputText, int maxSize, long parseDuration, int durationCheckFrequency)
+	public void extractText(String mimeType, InputStream input, StringBuilder outputText, int maxSize, long parseDuration)
 		throws IOException
 	{
-		// Ignore parseDuration and durationCheckFrequency for now.
+		// Ignore parseDuration for now.
 		try
 		{
 			Metadata meta = new Metadata();

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/extracter/standard/MsWordExtracter.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/extracter/standard/MsWordExtracter.java
@@ -52,9 +52,10 @@ public class MsWordExtracter extends AbstractTextExtracterExtension
 	}
 
 	@Override
-	public void extractText(String mimeType, InputStream input, StringBuilder outputText, int maxSize)
+	public void extractText(String mimeType, InputStream input, StringBuilder outputText, int maxSize, long parseDuration, int durationCheckFrequency)
 		throws IOException
 	{
+		// Ignore parseDuration and durationCheckFrequency for now.
 		try
 		{
 			Metadata meta = new Metadata();

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/extracter/standard/MsWordExtracter.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/extracter/standard/MsWordExtracter.java
@@ -52,10 +52,10 @@ public class MsWordExtracter extends AbstractTextExtracterExtension
 	}
 
 	@Override
-	public void extractText(String mimeType, InputStream input, StringBuilder outputText, int maxSize, long parseDuration, int durationCheckFrequency)
+	public void extractText(String mimeType, InputStream input, StringBuilder outputText, int maxSize, long parseDuration)
 		throws IOException
 	{
-		// Ignore parseDuration and durationCheckFrequency for now.
+		// Ignore parseDuration for now.
 		try
 		{
 			Metadata meta = new Metadata();

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/extracter/standard/PdfExtracter.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/extracter/standard/PdfExtracter.java
@@ -53,11 +53,11 @@ public class PdfExtracter extends AbstractTextExtracterExtension
 	}
 
 	@Override
-	public void extractText(String mimeType, InputStream input, StringBuilder outputText, int maxSize, long parseDuration, int durationCheckFrequency)
+	public void extractText(String mimeType, InputStream input, StringBuilder outputText, int maxSize, long parseDuration)
 		throws IOException
 	{
 		WriteOutContentHandler wrapped = new WriteOutContentHandler(maxSize);
-		ContentHandler handler = new CappedBodyContentHandler(wrapped, parseDuration, durationCheckFrequency);
+		ContentHandler handler = new CappedBodyContentHandler(wrapped, parseDuration);
 		try
 		{
 			Metadata meta = new Metadata();
@@ -65,7 +65,7 @@ public class PdfExtracter extends AbstractTextExtracterExtension
 			parser.parse(input, handler, meta, new ParseContext());
 
 			appendText(handler, outputText, maxSize);
-		
+
 		}
 		catch( Exception t )
 		{

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/extracter/standard/PdfExtracter.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/extracter/standard/PdfExtracter.java
@@ -21,12 +21,12 @@ import java.io.InputStream;
 
 import javax.inject.Singleton;
 
+import com.tle.core.freetext.extracter.handler.CappedBodyContentHandler;
 import org.apache.tika.config.TikaConfig;
 import org.apache.tika.metadata.Metadata;
 import org.apache.tika.parser.AutoDetectParser;
 import org.apache.tika.parser.ParseContext;
 import org.apache.tika.parser.Parser;
-import org.apache.tika.sax.BodyContentHandler;
 import org.apache.tika.sax.WriteOutContentHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,11 +53,11 @@ public class PdfExtracter extends AbstractTextExtracterExtension
 	}
 
 	@Override
-	public void extractText(String mimeType, InputStream input, StringBuilder outputText, int maxSize)
+	public void extractText(String mimeType, InputStream input, StringBuilder outputText, int maxSize, long parseDuration, int durationCheckFrequency)
 		throws IOException
 	{
 		WriteOutContentHandler wrapped = new WriteOutContentHandler(maxSize);
-		ContentHandler handler = new BodyContentHandler(wrapped);
+		ContentHandler handler = new CappedBodyContentHandler(wrapped, parseDuration, durationCheckFrequency);
 		try
 		{
 			Metadata meta = new Metadata();
@@ -65,6 +65,7 @@ public class PdfExtracter extends AbstractTextExtracterExtension
 			parser.parse(input, handler, meta, new ParseContext());
 
 			appendText(handler, outputText, maxSize);
+		
 		}
 		catch( Exception t )
 		{

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/extracter/standard/PlainTextExtracter.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/extracter/standard/PlainTextExtracter.java
@@ -43,10 +43,10 @@ public class PlainTextExtracter extends AbstractTextExtracterExtension
 	}
 
 	@Override
-	public void extractText(String mimeType, InputStream input, StringBuilder outputText, int maxSize, long parseDuration, int durationCheckFrequency)
+	public void extractText(String mimeType, InputStream input, StringBuilder outputText, int maxSize, long parseDuration)
 		throws IOException
 	{
-		// Ignore parseDuration and durationCheckFrequency for now.
+		// Ignore parseDuration for now.
 		int done = 0;
 		byte[] filebytes = new byte[maxSize];
 		while( done < maxSize )

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/extracter/standard/PlainTextExtracter.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/extracter/standard/PlainTextExtracter.java
@@ -43,9 +43,10 @@ public class PlainTextExtracter extends AbstractTextExtracterExtension
 	}
 
 	@Override
-	public void extractText(String mimeType, InputStream input, StringBuilder outputText, int maxSize)
+	public void extractText(String mimeType, InputStream input, StringBuilder outputText, int maxSize, long parseDuration, int durationCheckFrequency)
 		throws IOException
 	{
+		// Ignore parseDuration and durationCheckFrequency for now.
 		int done = 0;
 		byte[] filebytes = new byte[maxSize];
 		while( done < maxSize )

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/guice/FreetextModule.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/guice/FreetextModule.java
@@ -35,6 +35,8 @@ public class FreetextModule extends PropertiesModule
 		bindProp("freetextIndex.defaultOperator");
 		bindBoolean("textExtracter.indexAttachments");
 		bindBoolean("textExtracter.indexImsPackages");
+		bindLong("textExtracter.parseDurationCap");
+		bindInt("textExtracter.durationCheckFrequency");
 		install(new FreetextMandatoryModule());
 	}
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/guice/FreetextModule.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/freetext/guice/FreetextModule.java
@@ -36,7 +36,6 @@ public class FreetextModule extends PropertiesModule
 		bindBoolean("textExtracter.indexAttachments");
 		bindBoolean("textExtracter.indexImsPackages");
 		bindLong("textExtracter.parseDurationCap");
-		bindInt("textExtracter.durationCheckFrequency");
 		install(new FreetextMandatoryModule());
 	}
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/freetext/TextExtracter.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/freetext/TextExtracter.java
@@ -90,6 +90,12 @@ public class TextExtracter
 	@Inject(optional = true)
 	@Named("textExtracter.indexImsPackages")
 	private boolean indexImsPackages = true;
+	@Inject(optional = true)
+	@Named("textExtracter.parseDurationCap")
+	private long parseDurationCap = 60000;
+	@Inject(optional = true)
+	@Named("textExtracter.durationCheckFrequency")
+	private int durationCheckFrequency = 30;
 
 	@SuppressWarnings("nls")
 	public List<Fieldable> indexAttachments(IndexedItem indexedItem, SearchSettings searchSettings)
@@ -357,7 +363,7 @@ public class TextExtracter
 		String mimeType = mimeEntry != null ? mimeEntry.getType() : null;
 		if( extracters.size() > 0 )
 		{
-			extracters.get(0).extractText(mimeType, inp, outputText, SUMMARY_SIZE);
+			extracters.get(0).extractText(mimeType, inp, outputText, SUMMARY_SIZE, parseDurationCap, durationCheckFrequency);
 			outputText.append(' ');
 		}
 		else

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/freetext/TextExtracter.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/freetext/TextExtracter.java
@@ -93,9 +93,6 @@ public class TextExtracter
 	@Inject(optional = true)
 	@Named("textExtracter.parseDurationCap")
 	private long parseDurationCap = 60000;
-	@Inject(optional = true)
-	@Named("textExtracter.durationCheckFrequency")
-	private int durationCheckFrequency = 30;
 
 	@SuppressWarnings("nls")
 	public List<Fieldable> indexAttachments(IndexedItem indexedItem, SearchSettings searchSettings)
@@ -363,7 +360,7 @@ public class TextExtracter
 		String mimeType = mimeEntry != null ? mimeEntry.getType() : null;
 		if( extracters.size() > 0 )
 		{
-			extracters.get(0).extractText(mimeType, inp, outputText, SUMMARY_SIZE, parseDurationCap, durationCheckFrequency);
+			extracters.get(0).extractText(mimeType, inp, outputText, SUMMARY_SIZE, parseDurationCap);
 			outputText.append(' ');
 		}
 		else


### PR DESCRIPTION
Initially explored a way to interrupt the indexer thread, but the Tika AutoParser doesn't acknowledge interrupts.  I ended up creating a 'capped' parse handler for the Tika parser so it won't run indefinitely.  

New `com.tle.core.freetext` > `optional.properties`:
```
# Tuning config for attachment indexing.  Currently implemented for PDFs.
# The attachment indexing duration will go over this amount (in milliseconds), 
# but will be checked each time the parser returns data to the controller, 
# so it will be close
textExtracter.parseDurationCap=30000

# Tuning config for attachment indexing.  Specifies how many times to ignore 
# checking that the duration has not gone over it's cap before checking.  Slight 
# performance boost for higher values
textExtracter.durationCheckFrequency=15
```