### PR TITLE
#459 all restricted display attachments now display for a given path

### DIFF
--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/viewitem/summary/section/attachment/AttachmentsSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/viewitem/summary/section/attachment/AttachmentsSection.java
@@ -318,7 +318,7 @@ public class AttachmentsSection extends AbstractAttachmentsSection<Item, Attachm
 				final PropBagEx xml = vitem.getItemxml();
 				for( String target : metadataTargets )
 				{
-					for( String val : xml.getNodeList(target) )
+					for( String val : xml.iterateAllValues(target) )
 					{
 						if( val.equals(attachmentUuid) )
 						{


### PR DESCRIPTION
Simple change to allow all xml path results to be checked when determining restricted attachment display.