### PR TITLE
#476 XmlScriptType getParent and getChildren logic in place

### DIFF
--- a/Platform/Plugins/com.tle.platform.common/src/com/dytech/devlib/PropBagEx.java
+++ b/Platform/Plugins/com.tle.platform.common/src/com/dytech/devlib/PropBagEx.java
@@ -1076,10 +1076,43 @@ public class PropBagEx implements Serializable
 	public PropBagEx getParent()
 	{
 		ensureRoot();
-		final Element root = (Element) m_elRoot.getParentNode();
+		final Node rootNode = m_elRoot.getParentNode();
+		if(rootNode instanceof Element) {
+			final Element root = (Element) m_elRoot.getParentNode();
+			if( root != null )
+			{
+				return new PropBagEx(root, true);
+			}
+			else
+			{
+				return null;
+			}
+		} else {
+			return null;
+		}
+	}
+
+	/**
+	 * Creates a List of new PropBags rooted at each of the children of this PropBag, sharing the
+	 * same DOM nodes as the creator.
+	 *
+	 * @return List<PropBagEx> A list of children or null if the node does not exist.
+	 */
+	public List<PropBagEx> getChildren()
+	{
+		ensureRoot();
+		final Element root = (Element) m_elRoot;
 		if( root != null )
 		{
-			return new PropBagEx(root, true);
+			List<PropBagEx> childrenPropBagEx = new ArrayList<>();
+			NodeList childrenNodes = root.getChildNodes();
+			for(int i = 0; i < childrenNodes.getLength(); i++) {
+				Node n = childrenNodes.item(i);
+				if(n.getNodeType() == Node.ELEMENT_NODE) {
+					childrenPropBagEx.add(new PropBagEx(n, true));
+				}
+			}
+			return childrenPropBagEx;
 		}
 		else
 		{
@@ -1179,7 +1212,7 @@ public class PropBagEx implements Serializable
 	/**
 	 * Retrieves a node as an int value given it's name.
 	 * 
-	 * @param szFullNodeName full name of the node, parents qualified by '/'
+	 * @param path full name of the node, parents qualified by '/'
 	 * @return int value of the node
 	 */
 	public int getIntNode(final String path)
@@ -1193,7 +1226,7 @@ public class PropBagEx implements Serializable
 	 * exist or its value is an invalid integer, then the default value is
 	 * returned.
 	 * 
-	 * @param szFullNodeName full name of the node, parents qualified by '/'
+	 * @param path full name of the node, parents qualified by '/'
 	 * @param defaultValue A default value to return if the node does not exist.
 	 * @return value of the node.
 	 */

--- a/Source/Plugins/Core/com.equella.base/src/com/dytech/edge/common/PropBagWrapper.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/dytech/edge/common/PropBagWrapper.java
@@ -337,6 +337,25 @@ public class PropBagWrapper implements XmlScriptType
 		}
 	}
 
+
+	@Override
+	public XmlScriptType getParent() {
+		PathOverride override = getOverride("/", 0, bag); //$NON-NLS-1$
+		return override.getParent();
+	}
+
+	@Override
+	public List<XmlScriptType> getChildren() {
+		PathOverride override = getOverride("/", 0, bag); //$NON-NLS-1$
+		return override.getChildren();
+	}
+
+	@Override
+	public String getName() {
+		PathOverride override = getOverride("/", 0, bag); //$NON-NLS-1$
+		return override.getName();
+	}
+
 	private static class PathOverride
 	{
 		String path;
@@ -525,6 +544,40 @@ public class PropBagWrapper implements XmlScriptType
 				return;
 			}
 			override.appendChildren(path, docToAppend.bag);
+		}
+
+		public PropBagWrapper getParent() {
+			if(override == null) {
+				return null;
+			}
+
+			PropBagEx parent = override.getParent();
+			if(parent == null) {
+				return null;
+			} else {
+				return new PropBagWrapper(parent);
+			}
+		}
+
+		public List<XmlScriptType> getChildren() {
+			if(override == null) {
+				return null;
+			}
+
+			List<PropBagEx> rawResults = override.getChildren();
+			List<XmlScriptType> results = new ArrayList<>();
+			for(PropBagEx propBag : rawResults) {
+				results.add(new PropBagWrapper(propBag));
+			}
+			return results;
+		}
+
+		public String getName() {
+			if(override == null) {
+				return null;
+			}
+
+			return override.getNodeName();
 		}
 	}
 

--- a/Source/Plugins/Core/com.equella.base/src/com/tle/common/scripting/types/XmlScriptType.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/common/scripting/types/XmlScriptType.java
@@ -208,4 +208,27 @@ public interface XmlScriptType extends Serializable
 	 * @return A string representation of the XML
 	 */
 	String asString();
+
+	/**
+	 * Returns an XmlScriptType object for the sub-tree that is rooted at
+	 * 'this' object.
+	 *
+	 * @return The sub-tree rooted at the parent of the calling node.
+	 */
+	XmlScriptType getParent();
+
+	/**
+	 * Returns a List of XmlScriptType objects for the sub-trees rooted at
+	 * each of the children of 'this' object.
+	 *
+	 * @return The children of the calling node.
+	 */
+	List<XmlScriptType> getChildren();
+
+	/**
+	 * Returns 'this' XmlScriptType's name.
+	 *
+	 * @return The name of the calling node.
+	 */
+	String getName();
 }


### PR DESCRIPTION
For issue #476 .

Logic is in place to return the parent and children of a given `XmlScriptType`.  I added in a `XmlScriptType.getName()` as well.  The scripting below outputs the expected values.  I chose to go with the call format of `node.getParent()` instead of `node.getParent(node)` or `xml.getParent(node)`.  Both ways functionally worked, so I opted for the simplified way. 

```
xml.set("lom/general/title", "a title");
xml.set("lom/general/description", "a desc");
var titleXml = xml.getSubtree("lom/general/title");
var descXml = xml.getSubtree("lom/general/description");

displayChildren(xml);
displayLineage(xml.getSubtree("lom/general/title"));

var temp = utils.newXmlDocument();
temp.set("/parent1/child1", "p1c1");
temp.set("/parent1/child2", "p1c2");
temp.set("/parent1/child3", "p1c3");
temp.set("/parent2/child1", "p2c1");
temp.set("/parent2/child2", "p2c2");
displayChildren(temp);
displayLineage(temp.getSubtree("/parent2/child1"));

function displayChildren(n) {
	var children = n.getChildren();
	if(children != null) {
		if(children.size() == 0) {
			logger.log("No children found for: " + displayName(n));
		} else {
			logger.log(children.size() + " children found for: " + displayName(n));
			for(var i = 0; i < children.size(); i++) {
				logger.log("Child: " + children.get(i));
				displayChildren(children.get(i));
			}
		}
	} else {
		logger.log("Unable to find children for: " + displayName(n));
	}
}

function displayLineage(n) {
	var parent = n.getParent();
	logger.log("Parent of [" + displayName(n) + "] is [" + parent + "]");
	if(parent != null) {
		displayLineage(parent);
	}
}

function displayName(n) {
	if(n == null) return "NULL";
	else return n.getName();
}
```