### PR TITLE
#475 ControlScriptObject getParent and getIndex(child) implemented

### DIFF
--- a/Platform/Plugins/com.tle.platform.common/src/com/dytech/devlib/PropBagEx.java
+++ b/Platform/Plugins/com.tle.platform.common/src/com/dytech/devlib/PropBagEx.java
@@ -1077,7 +1077,8 @@ public class PropBagEx implements Serializable
 	{
 		ensureRoot();
 		final Node rootNode = m_elRoot.getParentNode();
-		if(rootNode instanceof Element) {
+		if(rootNode instanceof Element)
+		{
 			final Element root = (Element) m_elRoot.getParentNode();
 			if( root != null )
 			{
@@ -1087,7 +1088,9 @@ public class PropBagEx implements Serializable
 			{
 				return null;
 			}
-		} else {
+		}
+		else
+		{
 			return null;
 		}
 	}
@@ -1106,9 +1109,11 @@ public class PropBagEx implements Serializable
 		{
 			List<PropBagEx> childrenPropBagEx = new ArrayList<>();
 			NodeList childrenNodes = root.getChildNodes();
-			for(int i = 0; i < childrenNodes.getLength(); i++) {
+			for(int i = 0; i < childrenNodes.getLength(); i++)
+			{
 				Node n = childrenNodes.item(i);
-				if(n.getNodeType() == Node.ELEMENT_NODE) {
+				if(n.getNodeType() == Node.ELEMENT_NODE)
+				{
 					childrenPropBagEx.add(new PropBagEx(n, true));
 				}
 			}

--- a/Source/Plugins/Core/com.equella.base/src/com/dytech/edge/common/PropBagWrapper.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/dytech/edge/common/PropBagWrapper.java
@@ -339,19 +339,22 @@ public class PropBagWrapper implements XmlScriptType
 
 
 	@Override
-	public XmlScriptType getParent() {
+	public XmlScriptType getParent()
+	{
 		PathOverride override = getOverride("/", 0, bag); //$NON-NLS-1$
 		return override.getParent();
 	}
 
 	@Override
-	public List<XmlScriptType> getChildren() {
+	public List<XmlScriptType> getChildren()
+	{
 		PathOverride override = getOverride("/", 0, bag); //$NON-NLS-1$
 		return override.getChildren();
 	}
 
 	@Override
-	public String getName() {
+	public String getName()
+	{
 		PathOverride override = getOverride("/", 0, bag); //$NON-NLS-1$
 		return override.getName();
 	}
@@ -546,34 +549,44 @@ public class PropBagWrapper implements XmlScriptType
 			override.appendChildren(path, docToAppend.bag);
 		}
 
-		public PropBagWrapper getParent() {
-			if(override == null) {
+		public PropBagWrapper getParent()
+		{
+			if(override == null)
+			{
 				return null;
 			}
 
 			PropBagEx parent = override.getParent();
-			if(parent == null) {
+			if(parent == null)
+			{
 				return null;
-			} else {
+			}
+			else
+			{
 				return new PropBagWrapper(parent);
 			}
 		}
 
-		public List<XmlScriptType> getChildren() {
-			if(override == null) {
+		public List<XmlScriptType> getChildren()
+		{
+			if(override == null)
+			{
 				return null;
 			}
 
 			List<PropBagEx> rawResults = override.getChildren();
 			List<XmlScriptType> results = new ArrayList<>();
-			for(PropBagEx propBag : rawResults) {
+			for(PropBagEx propBag : rawResults)
+			{
 				results.add(new PropBagWrapper(propBag));
 			}
 			return results;
 		}
 
-		public String getName() {
-			if(override == null) {
+		public String getName()
+		{
+			if(override == null)
+			{
 				return null;
 			}
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/wizard/controls/HTMLControl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/wizard/controls/HTMLControl.java
@@ -136,4 +136,6 @@ public interface HTMLControl
 	HTMLControl getParent();
 
 	void setParent(HTMLControl parent);
+
+	int getIndex(HTMLControl child);
 }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/wizard/controls/HTMLCtrlWrapper.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/wizard/controls/HTMLCtrlWrapper.java
@@ -318,7 +318,8 @@ public class HTMLCtrlWrapper implements HTMLControl
 	}
 
 	@Override
-	public int getIndex(HTMLControl child) {
+	public int getIndex(HTMLControl child)
+	{
 		return control.getIndex(child);
 	}
 }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/wizard/controls/HTMLCtrlWrapper.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/wizard/controls/HTMLCtrlWrapper.java
@@ -316,4 +316,9 @@ public class HTMLCtrlWrapper implements HTMLControl
 	{
 		control.setParent(parent);
 	}
+
+	@Override
+	public int getIndex(HTMLControl child) {
+		return control.getIndex(child);
+	}
 }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/controls/AbstractHTMLControl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/controls/AbstractHTMLControl.java
@@ -573,4 +573,10 @@ public abstract class AbstractHTMLControl implements Serializable, HTMLControl
 	{
 		this.parent = parent;
 	}
+
+	@Override
+	public int getIndex(HTMLControl child) {
+		// By default.  Override if your control creates a list of controls, such as GroupsCtrl
+		return -1;
+	}
 }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/controls/AbstractHTMLControl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/controls/AbstractHTMLControl.java
@@ -575,7 +575,8 @@ public abstract class AbstractHTMLControl implements Serializable, HTMLControl
 	}
 
 	@Override
-	public int getIndex(HTMLControl child) {
+	public int getIndex(HTMLControl child)
+	{
 		// By default.  Override if your control creates a list of controls, such as GroupsCtrl
 		return -1;
 	}

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/controls/GroupsCtrl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/controls/GroupsCtrl.java
@@ -276,10 +276,14 @@ public class GroupsCtrl extends OptionCtrl
 	}
 
 	@Override
-	public int getIndex(HTMLControl child) {
-		for(int i = 0; i < groups.size(); i ++) {
-			for(HTMLControl control : groups.get(i).getControls()) {
-				if(control == child) {
+	public int getIndex(HTMLControl child)
+	{
+		for(int i = 0; i < groups.size(); i ++)
+		{
+			for(HTMLControl control : groups.get(i).getControls())
+			{
+				if(control == child)
+				{
 					return i;
 				}
 			}

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/controls/GroupsCtrl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/controls/GroupsCtrl.java
@@ -274,4 +274,17 @@ public class GroupsCtrl extends OptionCtrl
 			return controls.contains(control);
 		}
 	}
+
+	@Override
+	public int getIndex(HTMLControl child) {
+		for(int i = 0; i < groups.size(); i ++) {
+			for(HTMLControl control : groups.get(i).getControls()) {
+				if(control == child) {
+					return i;
+				}
+			}
+		}
+		return -1;
+	}
+
 }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/scripting/objects/ControlScriptObject.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/scripting/objects/ControlScriptObject.java
@@ -104,4 +104,21 @@ public interface ControlScriptObject extends ScriptObject
 	 * @return The ID or ID-prefix as rendered in the HTML
 	 */
 	String getFormId();
+
+	/**
+	 * Returns the parent of the calling ControlScriptObject.  A parent will exist
+	 * generally in the case when a control is nested in a group / repeater.
+	 * @return The ControlScriptObject parent, null if not available.
+	 */
+	ControlScriptObject getParent();
+
+	/**
+	 * Returns the index of the ControlScriptObject parameter, assuming there
+	 * is a direct parent-child relationship with the ControlScriptObject making
+	 * the call, and the parent is a list of ControlScriptObjects, such as a repeater.
+	 *
+	 * @return The index of the ControlScriptObject parameter, relative to it's parent.  -1 if not available.
+	 */
+	int getIndex(ControlScriptObject child);
+
 }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/scripting/objects/impl/ControlScriptWrapper.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/scripting/objects/impl/ControlScriptWrapper.java
@@ -121,18 +121,24 @@ public class ControlScriptWrapper implements ControlScriptObject
 	}
 
 	@Override
-	public ControlScriptObject getParent() {
+	public ControlScriptObject getParent()
+	{
 		// Controls of the same lineage are always on the same page.
-		if(control.getParent() == null) {
+		if(control.getParent() == null)
+		{
 			return null;
-		} else {
+		}
+		else
+		{
 			return new ControlScriptWrapper(control.getParent(), control.getWizardPage());
 		}
 	}
 
 	@Override
-	public int getIndex(ControlScriptObject child) {
-		if(child instanceof ControlScriptWrapper) {
+	public int getIndex(ControlScriptObject child)
+	{
+		if(child instanceof ControlScriptWrapper)
+		{
 			return control.getIndex(((ControlScriptWrapper) child).control);
 		}
 		return -1;

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/scripting/objects/impl/ControlScriptWrapper.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/scripting/objects/impl/ControlScriptWrapper.java
@@ -119,4 +119,22 @@ public class ControlScriptWrapper implements ControlScriptObject
 		}
 		return "p" + page.getPageNumber() + control.getFormName(); //$NON-NLS-1$
 	}
+
+	@Override
+	public ControlScriptObject getParent() {
+		// Controls of the same lineage are always on the same page.
+		if(control.getParent() == null) {
+			return null;
+		} else {
+			return new ControlScriptWrapper(control.getParent(), control.getWizardPage());
+		}
+	}
+
+	@Override
+	public int getIndex(ControlScriptObject child) {
+		if(child instanceof ControlScriptWrapper) {
+			return control.getIndex(((ControlScriptWrapper) child).control);
+		}
+		return -1;
+	}
 }


### PR DESCRIPTION
History in #475.  Allows scripting to be 'aware' of which repeater node the control is in.  