### PR TITLE
build: add dependency graph plugin

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -33,3 +33,5 @@ libraryDependencies ++= Seq(
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
+
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")


### PR DESCRIPTION
allows Equella's dependency graph to be visualized.
allows metadata to be extracted by dependency analysis tools.