### PR TITLE
Make course drop down entries more compact #632

### DIFF
--- a/Source/Plugins/Core/com.equella.core/resources/web/css/styles.css
+++ b/Source/Plugins/Core/com.equella.core/resources/web/css/styles.css
@@ -1467,22 +1467,8 @@ Expandable button
     display: flex;
 }
 
-
-
 /* Autocomplete dropdown */
-.autocomplete-result {
-}
-.autocomplete-result-title {
-}
-.autocomplete-result-description {
-}
 
-select {
-}
-
-.equella-dropdown {
-    /*z-index: 999999 !important;*/
-}
 .equella-dropdown-list {
     z-index: 999999 !important;
 }

--- a/Source/Plugins/Core/com.equella.core/resources/web/css/styles.css
+++ b/Source/Plugins/Core/com.equella.core/resources/web/css/styles.css
@@ -1471,19 +1471,13 @@ Expandable button
 
 /* Autocomplete dropdown */
 .autocomplete-result {
-    min-height: 32px;
 }
 .autocomplete-result-title {
-    font-size: 14px;
-    font-weight: bold;
 }
 .autocomplete-result-description {
-    margin-top: 8px;
-    font-style: italic;
 }
 
 select {
-  width: 100%;
 }
 
 .equella-dropdown {


### PR DESCRIPTION
The font size and spacing assigned to each drop down entry was too
large and so the lines of CSS that caused this were removed.