### PR TITLE
Increase page size to 10 from 6 (fixes #651)

### DIFF
--- a/Source/Plugins/Core/com.equella.core/resources/web/scripts/component/select2helper.js
+++ b/Source/Plugins/Core/com.equella.core/resources/web/scripts/component/select2helper.js
@@ -3,7 +3,7 @@ var select2helper = {};
 (function() {
     this.setup = function($elem, params, extension) {
         var p = {};
-        var perpage = 6;
+        var perpage = 10;
 
         var ajax = undefined;
         if (params.ajaxurl) {


### PR DESCRIPTION
Scrolling is what triggers the loading of new results within select2.
Because of this, the page size must be longer so that there will always
be enough room to scroll and the list will load properly.