### PR TITLE
#578 Fixed spelling of group name for M.D.F.

### DIFF
--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/settings/SettingsList.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/settings/SettingsList.scala
@@ -108,7 +108,7 @@ object SettingsList {
     CoreSettingsPage("quickcontrib", General, "quickcontributeandversionsettings.title", "quickcontributeandversionsettings.description",
       "access/quickcontributeandversionsettings.do", quickContribPrivProvider.isAuthorised),
 
-    CoreSettingsPage("datafixes", "diagnostic", "fix.settings.title", "fix.settings.description",
+    CoreSettingsPage("datafixes", "diagnostics", "fix.settings.title", "fix.settings.description",
       "access/manualdatafixes.do", manualFixPrivProvider.isAuthorised),
 
     CoreSettingsPage("oai", Integration, "oai.title", "oaiidentifier.description",


### PR DESCRIPTION
Group name of 'diagnostics' was singular, and thus not being picked up in the UI.  Fixed spelling.