### PR TITLE
build: configure renovate bot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,10 @@
+{
+    "extends": [
+      "config:base",
+      ":rebaseStalePrs",
+      ":preserveSemverRanges",
+      ":semanticPrefixChore",
+      ":disableRateLimiting"
+    ],
+    "renovateFork": true
+  }


### PR DESCRIPTION
Renovate bot provides a way to automate dependency upgrades.
Whenever new versions become available on NPM a pull request will be opened patching `package.json` and `yarn.lock` for the new version.

Renovate is open source https://github.com/renovatebot
It can be run run as a GitHub app https://github.com/marketplace/renovate
Or can be self hosted https://github.com/renovatebot/renovate#self-hosting

For an example of PRs that will be generated see PRs 1-13 at https://github.com/ChristianMurphy/Equella/pulls

:notebook: Renovate also supports Maven/Gradle, with a new data source it could support SBT as well.