### PR TITLE
more precise 'where clause' docs link

### DIFF
--- a/Source/Plugins/Core/com.equella.base/src/com/tle/web/api/search/interfaces/SearchResource.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/web/api/search/interfaces/SearchResource.java
@@ -54,7 +54,7 @@ public interface SearchResource
 		@ApiParam(value="List of collections", required = false)
 		@QueryParam("collections")
 			CsvList collections,
-		@ApiParam(value="The where-clause in the same format as the old SOAP one. See https://equella.github.io/",
+		@ApiParam(value="For details on structuring the where clause see https://equella.github.io/guides/RestAPIGuide.html#searching",
 					required = false)
 		@QueryParam("where")
 			String where,

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/api/search/EquellaSearchResource.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/api/search/EquellaSearchResource.java
@@ -95,8 +95,8 @@ public interface EquellaSearchResource extends SearchResource
 			@ApiParam(value="Reverse the order of the search results", allowableValues = ",true,false", defaultValue = "false", required = false)
 			@QueryParam("reverse")
 				String reverse,
-			
-			@ApiParam(value="The where-clause in the same format as the old SOAP one. See https://equella.github.io/",
+
+			@ApiParam(value="For details on structuring the where clause see https://equella.github.io/guides/RestAPIGuide.html#searching",
 						required = false)
 			@QueryParam("where")
 				String where,

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/myresources/api/search/SearchMyResource.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/myresources/api/search/SearchMyResource.java
@@ -124,12 +124,12 @@ public class SearchMyResource
 		@ApiParam(value="Reverse the order of the search results", allowableValues = "true,false", defaultValue = "false", required = false) 
 		@QueryParam("reverse") 
 			String reverse,
-		@ApiParam(value="The where-clause in the same format as the old SOAP one. See https://equella.github.io/",
-					required = false) @QueryParam("where") 
-			String where, 
-		@ApiParam(value="How much information to return for the results", required = false, 
-					allowableValues = ItemResource.ALL_ALLOWABLE_INFOS, 
-					allowMultiple = true) @QueryParam("info") 
+		@ApiParam(value="For details on structuring the where clause see https://equella.github.io/guides/RestAPIGuide.html#searching",
+					required = false) @QueryParam("where")
+			String where,
+		@ApiParam(value="How much information to return for the results", required = false,
+					allowableValues = ItemResource.ALL_ALLOWABLE_INFOS,
+					allowMultiple = true) @QueryParam("info")
 			CsvList info
 		)
 		// @formatter:on


### PR DESCRIPTION
see #730 for discussion—remove reference to SOAP, make the documentation link more specific and useful

Second take at this—I've made the bugfix branch based off of `develop` rather than `master`. Let me know if it's still not right, I don't know a easier way to do this than to delete the old remote branch and try again.