### PR TITLE
Login notice: Rework UI of configurator based on UX review

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/loginnotice/LoginNoticeConfigPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/loginnotice/LoginNoticeConfigPage.tsx
@@ -64,24 +64,31 @@ class LoginNoticeConfigPage extends React.Component<LoginNoticeConfigPageProps, 
     }
   };
 
-  handleChange = (event: React.ChangeEvent<{}>, value:number) => {
-    this.setState({selectedTab:value})
+  handleChange = (event: React.ChangeEvent<{}>, value: number) => {
+    this.setState({selectedTab: value})
   };
 
   render() {
     const {Template} = this.props.bridge;
     return (
-      <Template title={strings.title} errorResponse={this.state.error || undefined}>
-        <Tabs centered value = {this.state.selectedTab} onChange={this.handleChange}>
-          <Tab label={strings.prelogin.label}/>
-          <Tab label={strings.postlogin.label}/>
-        </Tabs>
-        {this.state.selectedTab==0 && <PreLoginNoticeConfigurator handleError={this.handleError} onSaved={() =>this.setState({saved:true})} onDeleted={() =>this.setState({deleted:true})}/>}
-        {this.state.selectedTab==1 && <PostLoginNoticeConfigurator handleError={this.handleError} onSaved={() =>this.setState({saved:true})} onDeleted={() =>this.setState({deleted:true})}/>}
-          <MessageInfo title={strings.notifications.saveddescription} open={this.state.saved}
-                       onClose={() => this.setState({saved: false})} variant="success"/>
-          <MessageInfo title={strings.notifications.deletedescription} open={this.state.deleted}
-                       onClose={() => this.setState({deleted: false})} variant="success"/>
+      <Template title={strings.title}
+                tabs={
+                  <Tabs value={this.state.selectedTab} onChange={this.handleChange} fullWidth>
+                    <Tab label={strings.prelogin.label}/>
+                    <Tab label={strings.postlogin.label}/>
+                  </Tabs>}
+                errorResponse={this.state.error || undefined}
+      >
+        {this.state.selectedTab == 0 &&
+        <PreLoginNoticeConfigurator handleError={this.handleError} onSaved={() => this.setState({saved: true})}
+                                    onDeleted={() => this.setState({deleted: true})}/>}
+        {this.state.selectedTab == 1 &&
+        <PostLoginNoticeConfigurator handleError={this.handleError} onSaved={() => this.setState({saved: true})}
+                                     onDeleted={() => this.setState({deleted: true})}/>}
+        <MessageInfo title={strings.notifications.saveddescription} open={this.state.saved}
+                     onClose={() => this.setState({saved: false})} variant="success"/>
+        <MessageInfo title={strings.notifications.deletedescription} open={this.state.deleted}
+                     onClose={() => this.setState({deleted: false})} variant="success"/>
       </Template>
     );
   }

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/loginnotice/LoginNoticeConfigPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/loginnotice/LoginNoticeConfigPage.tsx
@@ -6,6 +6,8 @@ import MessageInfo from "../components/MessageInfo";
 import {ErrorResponse, generateFromAxiosError} from "../api/errors";
 import PreLoginNoticeConfigurator from "./PreLoginNoticeConfigurator";
 import PostLoginNoticeConfigurator from "./PostLoginNoticeConfigurator";
+import {Tabs} from "@material-ui/core";
+import Tab from "@material-ui/core/Tab";
 
 interface LoginNoticeConfigPageProps {
   bridge: Bridge;
@@ -14,7 +16,8 @@ interface LoginNoticeConfigPageProps {
 interface LoginNoticeConfigPageState {
   saved: boolean,
   deleted: boolean,
-  error?: ErrorResponse
+  error?: ErrorResponse,
+  selectedTab: number
 }
 
 export const strings = prepLangStrings("loginnoticepage",
@@ -44,7 +47,8 @@ class LoginNoticeConfigPage extends React.Component<LoginNoticeConfigPageProps, 
   state: LoginNoticeConfigPageState = {
     saved: false,
     deleted: false,
-    error: undefined
+    error: undefined,
+    selectedTab: 0
   };
 
   handleError = (axiosError: AxiosError) => {
@@ -60,12 +64,20 @@ class LoginNoticeConfigPage extends React.Component<LoginNoticeConfigPageProps, 
     }
   };
 
+  handleChange = (event: React.ChangeEvent<{}>, value:number) => {
+    this.setState({selectedTab:value})
+  };
+
   render() {
     const {Template} = this.props.bridge;
     return (
       <Template title={strings.title} errorResponse={this.state.error || undefined}>
-        <PreLoginNoticeConfigurator handleError={this.handleError} onSaved={() =>this.setState({saved:true})} onDeleted={() =>this.setState({deleted:true})}/>
-        <PostLoginNoticeConfigurator handleError={this.handleError} onSaved={() =>this.setState({saved:true})} onDeleted={() =>this.setState({deleted:true})}/>
+        <Tabs centered value = {this.state.selectedTab} onChange={this.handleChange}>
+          <Tab label={strings.prelogin.label}/>
+          <Tab label={strings.postlogin.label}/>
+        </Tabs>
+        {this.state.selectedTab==0 && <PreLoginNoticeConfigurator handleError={this.handleError} onSaved={() =>this.setState({saved:true})} onDeleted={() =>this.setState({deleted:true})}/>}
+        {this.state.selectedTab==1 && <PostLoginNoticeConfigurator handleError={this.handleError} onSaved={() =>this.setState({saved:true})} onDeleted={() =>this.setState({deleted:true})}/>}
           <MessageInfo title={strings.notifications.saveddescription} open={this.state.saved}
                        onClose={() => this.setState({saved: false})} variant="success"/>
           <MessageInfo title={strings.notifications.deletedescription} open={this.state.deleted}

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/loginnotice/LoginNoticeConfigPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/loginnotice/LoginNoticeConfigPage.tsx
@@ -24,7 +24,7 @@ interface LoginNoticeConfigPageState {
 export const strings = prepLangStrings("loginnoticepage",
   {
     title: "Login Notice Editor",
-    currentnotice:"Current Notice: ",
+    currentnotice: "Current Notice: ",
     prelogin: {
       label: "Before Login Notice",
       description: "Write a plaintext message to be displayed on the login screen..."
@@ -72,8 +72,22 @@ class LoginNoticeConfigPage extends React.Component<LoginNoticeConfigPageProps, 
     this.setState({selectedTab: value})
   };
 
+  Notifications = () => {
+    return (
+      <div>
+        <MessageInfo title={strings.notifications.saveddescription} open={this.state.saved}
+                     onClose={() => this.setState({saved: false})} variant="success"/>
+        <MessageInfo title={strings.notifications.deletedescription} open={this.state.deleted}
+                     onClose={() => this.setState({deleted: false})} variant="success"/>
+        <MessageInfo title={strings.notifications.undodescription} open={this.state.undone}
+                     onClose={() => this.setState({undone: false})} variant="info"/>
+      </div>
+    );
+  };
+
   render() {
     const {Template} = this.props.bridge;
+    const Notifications = this.Notifications;
     return (
       <Template title={strings.title}
                 tabs={
@@ -85,16 +99,13 @@ class LoginNoticeConfigPage extends React.Component<LoginNoticeConfigPageProps, 
       >
         {this.state.selectedTab == 0 &&
         <PreLoginNoticeConfigurator handleError={this.handleError} onSaved={() => this.setState({saved: true})}
-                                    onDeleted={() => this.setState({deleted: true})} onUndone={() => this.setState({undone: true})}/>}
+                                    onDeleted={() => this.setState({deleted: true})}
+                                    onUndone={() => this.setState({undone: true})}/>}
         {this.state.selectedTab == 1 &&
         <PostLoginNoticeConfigurator handleError={this.handleError} onSaved={() => this.setState({saved: true})}
-                                     onDeleted={() => this.setState({deleted: true})} onUndone={() => this.setState({undone: true})}/>}
-        <MessageInfo title={strings.notifications.saveddescription} open={this.state.saved}
-                     onClose={() => this.setState({saved: false})} variant="success"/>
-        <MessageInfo title={strings.notifications.deletedescription} open={this.state.deleted}
-                     onClose={() => this.setState({deleted: false})} variant="success"/>
-        <MessageInfo title={strings.notifications.undodescription} open={this.state.undone}
-                     onClose={() => this.setState({undone:false})} variant="info"/>
+                                     onDeleted={() => this.setState({deleted: true})}
+                                     onUndone={() => this.setState({undone: true})}/>}
+        <Notifications/>
       </Template>
     );
   }

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/loginnotice/LoginNoticeConfigPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/loginnotice/LoginNoticeConfigPage.tsx
@@ -16,6 +16,7 @@ interface LoginNoticeConfigPageProps {
 interface LoginNoticeConfigPageState {
   saved: boolean,
   deleted: boolean,
+  undone: boolean,
   error?: ErrorResponse,
   selectedTab: number
 }
@@ -23,6 +24,7 @@ interface LoginNoticeConfigPageState {
 export const strings = prepLangStrings("loginnoticepage",
   {
     title: "Login Notice Editor",
+    currentnotice:"Current Notice: ",
     prelogin: {
       label: "Before Login Notice",
       description: "Write a plaintext message to be displayed on the login screen..."
@@ -33,7 +35,8 @@ export const strings = prepLangStrings("loginnoticepage",
     },
     notifications: {
       saveddescription: "Login notice saved successfully.",
-      deletedescription: "Login notice deleted successfully."
+      deletedescription: "Login notice deleted successfully.",
+      undodescription: "Reverted changes to login notice."
     }
   }
 );
@@ -47,6 +50,7 @@ class LoginNoticeConfigPage extends React.Component<LoginNoticeConfigPageProps, 
   state: LoginNoticeConfigPageState = {
     saved: false,
     deleted: false,
+    undone: false,
     error: undefined,
     selectedTab: 0
   };
@@ -81,14 +85,16 @@ class LoginNoticeConfigPage extends React.Component<LoginNoticeConfigPageProps, 
       >
         {this.state.selectedTab == 0 &&
         <PreLoginNoticeConfigurator handleError={this.handleError} onSaved={() => this.setState({saved: true})}
-                                    onDeleted={() => this.setState({deleted: true})}/>}
+                                    onDeleted={() => this.setState({deleted: true})} onUndone={() => this.setState({undone: true})}/>}
         {this.state.selectedTab == 1 &&
         <PostLoginNoticeConfigurator handleError={this.handleError} onSaved={() => this.setState({saved: true})}
-                                     onDeleted={() => this.setState({deleted: true})}/>}
+                                     onDeleted={() => this.setState({deleted: true})} onUndone={() => this.setState({undone: true})}/>}
         <MessageInfo title={strings.notifications.saveddescription} open={this.state.saved}
                      onClose={() => this.setState({saved: false})} variant="success"/>
         <MessageInfo title={strings.notifications.deletedescription} open={this.state.deleted}
                      onClose={() => this.setState({deleted: false})} variant="success"/>
+        <MessageInfo title={strings.notifications.undodescription} open={this.state.undone}
+                     onClose={() => this.setState({undone:false})} variant="info"/>
       </Template>
     );
   }

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/loginnotice/LoginNoticeConfigPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/loginnotice/LoginNoticeConfigPage.tsx
@@ -25,6 +25,10 @@ export const strings = prepLangStrings("loginnoticepage",
   {
     title: "Login Notice Editor",
     currentnotice: "Current Notice: ",
+    delete:{
+      title:"Warning",
+      confirm: "Are you sure you want to delete this login notice?",
+    },
     prelogin: {
       label: "Before Login Notice",
       description: "Write a plaintext message to be displayed on the login screen..."

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/loginnotice/PostLoginNoticeConfigurator.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/loginnotice/PostLoginNoticeConfigurator.tsx
@@ -66,26 +66,27 @@ class PostLoginNoticeConfigurator extends React.Component<PostLoginNoticeConfigu
         <Grid id="postLoginConfig" container spacing={8} direction="column">
           <Grid item>
             <TextField id="postNoticeField"
-                       rows="10"
+                       rows="35"
+                       fullWidth
                        variant="outlined"
                        multiline
                        placeholder={strings.postlogin.description}
                        onChange={e => this.handlePostTextFieldChange(e.target)}
                        value={this.state.postNotice}/>
           </Grid>
-          <Grid item container spacing={8} direction="row">
+          <Grid item container spacing={8} direction="row-reverse">
             <Grid item>
               <Button id="postApplyButton"
                       onClick={this.handleSubmitPostNotice}
                       variant="contained">
-                {commonString.action.apply}
+                {commonString.action.save}
               </Button>
             </Grid>
             <Grid item>
               <Button id="postDeleteButton"
                       disabled={this.state.postNotice == ""}
                       onClick={this.handleDeletePostNotice}
-                      variant="contained">
+                      variant="text">
                 {commonString.action.delete}
               </Button>
             </Grid>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/loginnotice/PostLoginNoticeConfigurator.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/loginnotice/PostLoginNoticeConfigurator.tsx
@@ -1,10 +1,13 @@
 import * as React from "react";
 import {strings} from "./LoginNoticeConfigPage";
-import {Button, Grid, TextField, Typography} from "@material-ui/core";
+import {Button, DialogContent, DialogContentText, Grid, TextField, Typography} from "@material-ui/core";
 import {commonString} from "../util/commonstrings";
 import {deletePostLoginNotice, getPostLoginNotice, submitPostLoginNotice} from "./LoginNoticeModule";
 import {AxiosError, AxiosResponse} from "axios";
 import SettingsMenuContainer from "../components/SettingsMenuContainer";
+import Dialog from "@material-ui/core/Dialog";
+import DialogTitle from "@material-ui/core/DialogTitle";
+import DialogActions from "@material-ui/core/DialogActions";
 
 interface PostLoginNoticeConfiguratorProps {
   handleError: (axiosError: AxiosError) => void;
@@ -16,6 +19,7 @@ interface PostLoginNoticeConfiguratorProps {
 interface PostLoginNoticeConfiguratorState {
   postNotice?: string,               //what is currently in the textfield
   dbpostNotice?: string              //what is currently in the database
+  deleteStaged: boolean
 }
 
 class PostLoginNoticeConfigurator extends React.Component<PostLoginNoticeConfiguratorProps, PostLoginNoticeConfiguratorState> {
@@ -24,6 +28,7 @@ class PostLoginNoticeConfigurator extends React.Component<PostLoginNoticeConfigu
     this.state = ({
       postNotice: "",
       dbpostNotice: "",
+      deleteStaged: false
     });
   };
 
@@ -44,7 +49,7 @@ class PostLoginNoticeConfigurator extends React.Component<PostLoginNoticeConfigu
     this.setState({postNotice: ""});
     deletePostLoginNotice()
       .then(() => {
-        this.setState({dbpostNotice: ""});
+        this.setState({dbpostNotice: "", deleteStaged:false});
         this.props.onDeleted();
       })
       .catch((error:AxiosError) => {
@@ -71,8 +76,32 @@ class PostLoginNoticeConfigurator extends React.Component<PostLoginNoticeConfigu
       });
   };
 
+  stageDelete = () => {
+    this.setState({deleteStaged:true});
+  };
+
+  Dialogs = () => {
+    return(
+      <div>
+        <Dialog open={this.state.deleteStaged} onClose={()=>this.setState({deleteStaged:false})}>
+          <DialogTitle>{strings.delete.title}</DialogTitle>
+          <DialogContent>
+            <DialogContentText>
+              {strings.delete.confirm}
+            </DialogContentText>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={this.handleDeletePostNotice}>{commonString.action.ok}</Button>
+            <Button onClick={() =>this.setState({deleteStaged:false})}>{commonString.action.cancel}</Button>
+          </DialogActions>
+        </Dialog>
+      </div>
+    );
+  };
+
   render() {
     const {postNotice, dbpostNotice} = this.state;
+    const Dialogs = this.Dialogs;
     return (
       <SettingsMenuContainer>
         <Typography color="textSecondary" variant="subheading">{strings.postlogin.label}</Typography>
@@ -99,7 +128,7 @@ class PostLoginNoticeConfigurator extends React.Component<PostLoginNoticeConfigu
             <Grid item>
               <Button id="postDeleteButton"
                       disabled={dbpostNotice == ""}
-                      onClick={this.handleDeletePostNotice}
+                      onClick={this.stageDelete}
                       variant="text">
                 {commonString.action.delete}
               </Button>
@@ -114,6 +143,7 @@ class PostLoginNoticeConfigurator extends React.Component<PostLoginNoticeConfigu
             </Grid>
           </Grid>
         </Grid>
+        <Dialogs/>
       </SettingsMenuContainer>
     )
   }

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/loginnotice/PreLoginNoticeConfigurator.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/loginnotice/PreLoginNoticeConfigurator.tsx
@@ -1,11 +1,10 @@
 import * as React from "react";
 import {strings} from "./LoginNoticeConfigPage";
-import SettingsMenuContainer from "../components/SettingsMenuContainer";
-import {Button, Grid, TextField} from "@material-ui/core";
+import {Button, Grid, TextField, Typography} from "@material-ui/core";
 import {commonString} from "../util/commonstrings";
 import {deletePreLoginNotice, getPreLoginNotice, submitPreLoginNotice} from "./LoginNoticeModule";
 import {AxiosError, AxiosResponse} from "axios";
-import Typography from "@material-ui/core/Typography";
+import SettingsMenuContainer from "../components/SettingsMenuContainer";
 
 interface PreLoginNoticeConfiguratorProps {
   handleError: (axiosError: AxiosError) => void;
@@ -66,26 +65,27 @@ class PreLoginNoticeConfigurator extends React.Component<PreLoginNoticeConfigura
         <Grid id="preLoginConfig" container spacing={8} direction="column">
           <Grid item>
             <TextField id="preNoticeField"
-                       rows="10"
+                       rows="35"
                        variant="outlined"
                        multiline
+                       fullWidth
                        placeholder={strings.prelogin.description}
                        onChange={e => this.handlePreTextFieldChange(e.target)}
                        value={this.state.preNotice}/>
           </Grid>
-          <Grid item container spacing={8} direction="row">
+          <Grid item container spacing={8} direction="row-reverse">
             <Grid item>
               <Button id="preApplyButton"
                       onClick={this.handleSubmitPreNotice}
                       variant="contained">
-                {commonString.action.apply}
+                {commonString.action.save}
               </Button>
             </Grid>
             <Grid item>
               <Button id="preDeleteButton"
                       disabled={this.state.preNotice == ""}
                       onClick={this.handleDeletePreNotice}
-                      variant="contained">
+                      variant="text">
                 {commonString.action.delete}
               </Button>
             </Grid>

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/loginnotice/PreLoginNoticeConfigurator.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/loginnotice/PreLoginNoticeConfigurator.tsx
@@ -1,10 +1,13 @@
 import * as React from "react";
 import {strings} from "./LoginNoticeConfigPage";
-import {Button, Grid, TextField, Typography} from "@material-ui/core";
+import {Button, DialogContent, DialogContentText, Grid, TextField, Typography} from "@material-ui/core";
 import {commonString} from "../util/commonstrings";
 import {deletePreLoginNotice, getPreLoginNotice, submitPreLoginNotice} from "./LoginNoticeModule";
 import {AxiosError, AxiosResponse} from "axios";
 import SettingsMenuContainer from "../components/SettingsMenuContainer";
+import Dialog from "@material-ui/core/Dialog";
+import DialogTitle from "@material-ui/core/DialogTitle";
+import DialogActions from "@material-ui/core/DialogActions";
 
 interface PreLoginNoticeConfiguratorProps {
   handleError: (axiosError: AxiosError) => void;
@@ -16,6 +19,7 @@ interface PreLoginNoticeConfiguratorProps {
 interface PreLoginNoticeConfiguratorState {
   preNotice?: string,               //what is currently in the textfield
   dbpreNotice?: string              //what is currently in the database
+  deleteStaged: boolean
 }
 
 class PreLoginNoticeConfigurator extends React.Component<PreLoginNoticeConfiguratorProps, PreLoginNoticeConfiguratorState> {
@@ -24,6 +28,7 @@ class PreLoginNoticeConfigurator extends React.Component<PreLoginNoticeConfigura
     this.state = ({
       preNotice: "",
       dbpreNotice: "",
+      deleteStaged: false
     });
   };
 
@@ -44,7 +49,7 @@ class PreLoginNoticeConfigurator extends React.Component<PreLoginNoticeConfigura
     this.setState({preNotice: ""});
     deletePreLoginNotice()
       .then(() => {
-        this.setState({dbpreNotice: ""});
+        this.setState({dbpreNotice: "", deleteStaged:false});
         this.props.onDeleted();
       })
       .catch((error:AxiosError) => {
@@ -71,8 +76,32 @@ class PreLoginNoticeConfigurator extends React.Component<PreLoginNoticeConfigura
       });
   };
 
+  stageDelete = () => {
+    this.setState({deleteStaged:true});
+  };
+
+  Dialogs = () => {
+    return(
+      <div>
+        <Dialog open={this.state.deleteStaged} onClose={()=>this.setState({deleteStaged:false})}>
+          <DialogTitle>{strings.delete.title}</DialogTitle>
+          <DialogContent>
+            <DialogContentText>
+              {strings.delete.confirm}
+            </DialogContentText>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={this.handleDeletePreNotice}>{commonString.action.ok}</Button>
+            <Button onClick={() =>this.setState({deleteStaged:false})}>{commonString.action.cancel}</Button>
+          </DialogActions>
+        </Dialog>
+      </div>
+    );
+  };
+
   render() {
     const {preNotice, dbpreNotice} = this.state;
+    const Dialogs = this.Dialogs;
     return (
       <SettingsMenuContainer>
         <Typography color="textSecondary" variant="subheading">{strings.prelogin.label}</Typography>
@@ -99,7 +128,7 @@ class PreLoginNoticeConfigurator extends React.Component<PreLoginNoticeConfigura
             <Grid item>
               <Button id="preDeleteButton"
                       disabled={dbpreNotice == ""}
-                      onClick={this.handleDeletePreNotice}
+                      onClick={this.stageDelete}
                       variant="text">
                 {commonString.action.delete}
               </Button>
@@ -114,6 +143,7 @@ class PreLoginNoticeConfigurator extends React.Component<PreLoginNoticeConfigura
             </Grid>
           </Grid>
         </Grid>
+        <Dialogs/>
       </SettingsMenuContainer>
     )
   }


### PR DESCRIPTION
UI of the login notice configurator has been changed to a tabbed format. Also added a "Revert changes" button, changed the disable conditions of the buttons (save and revert changes are only enabled if the content of the textfield differs from the content of the database, and delete is only enabled if the database contains a login notice at all) and added a deletion confirmation dialog.

#660 

![image](https://user-images.githubusercontent.com/24543345/52189592-94980000-288d-11e9-9b01-d28e292e89f6.png)
