### PR TITLE
Fixing saving items without mandatory fields filled in

### DIFF
--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/WizardService.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/WizardService.java
@@ -30,6 +30,7 @@ import com.tle.core.item.operations.WorkflowOperation;
 import com.tle.core.wizard.controls.HTMLControl;
 import com.tle.core.wizard.controls.WizardPage;
 import com.tle.web.sections.SectionInfo;
+import com.tle.web.sections.js.JSCallable;
 import com.tle.web.viewable.ViewableItem;
 import java.util.Collection;
 import java.util.List;
@@ -154,4 +155,7 @@ public interface WizardService extends ScriptEvaluator {
   void updateSession(SectionInfo info, WizardStateInterface state);
 
   Object getThreadLock();
+
+  void ensureInitialisedPage(
+      SectionInfo info, WebWizardPage page, JSCallable reloadFunction, boolean load);
 }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/impl/WizardServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/impl/WizardServiceImpl.java
@@ -84,6 +84,7 @@ import com.tle.core.wizard.controls.HTMLControl;
 import com.tle.web.controls.universal.handlers.fileupload.FileUploadState;
 import com.tle.web.sections.Bookmark;
 import com.tle.web.sections.SectionInfo;
+import com.tle.web.sections.js.JSCallable;
 import com.tle.web.viewable.PreviewableItem;
 import com.tle.web.viewable.ViewableItem;
 import com.tle.web.viewable.impl.ViewableItemFactory;
@@ -1331,5 +1332,24 @@ public class WizardServiceImpl
   @BindFactory
   public interface WizardOperationFactory {
     WizardStateOperation state(WizardState state);
+  }
+
+  @Override
+  public void ensureInitialisedPage(
+      SectionInfo info, WebWizardPage page, JSCallable reloadFunction, boolean load) {
+    boolean doLoad = load;
+    try {
+      if (!page.isLoaded()) {
+        page.setReloadFunction(reloadFunction);
+        page.createPage();
+        doLoad = true;
+      }
+      if (doLoad) {
+        page.loadFromDocument(info);
+        page.saveDefaults();
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/section/PagesSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/section/PagesSection.java
@@ -25,10 +25,7 @@ import com.tle.core.i18n.BundleCache;
 import com.tle.core.item.helper.ItemHelper;
 import com.tle.core.wizard.LERepository;
 import com.tle.core.wizard.controls.HTMLControl;
-import com.tle.web.sections.SectionId;
-import com.tle.web.sections.SectionInfo;
-import com.tle.web.sections.SectionResult;
-import com.tle.web.sections.SectionTree;
+import com.tle.web.sections.*;
 import com.tle.web.sections.ajax.AjaxGenerator;
 import com.tle.web.sections.ajax.AjaxRenderContext;
 import com.tle.web.sections.ajax.JSONResponseCallback;
@@ -74,6 +71,10 @@ public class PagesSection extends WizardSection<PagesSection.PagesModel>
   @Override
   public String getDefaultPropertyName() {
     return "pages"; //$NON-NLS-1$
+  }
+
+  public JSCallable getReloadFunction() {
+    return reloadFunction;
   }
 
   @Override
@@ -159,22 +160,9 @@ public class PagesSection extends WizardSection<PagesSection.PagesModel>
       throw new Error("No pages in wizard");
     }
     WebWizardPage page = pages.get(pageNum);
-    boolean doLoad = load;
-    try {
-      if (!page.isLoaded()) {
-        page.setReloadFunction(reloadFunction);
-        page.createPage();
-        doLoad = true;
-      }
-      if (doLoad) {
-        page.loadFromDocument(info);
-        page.saveDefaults();
-      }
-      page.ensureTreeAdded(info, params);
-      return page;
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
+    wizardService.ensureInitialisedPage(info, page, reloadFunction, load);
+    page.ensureTreeAdded(info, params);
+    return page;
   }
 
   protected List<WebWizardPage> getPages(WizardState state) {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/section/RootWizardSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/section/RootWizardSection.java
@@ -158,6 +158,7 @@ public class RootWizardSection extends TwoColumnLayout<WizardForm>
     final WizardState state = wizardService.newItem(model.getItemdefUuid());
     initState(info, state);
     state.setEditable(true);
+    validateMandatoryFields(info, state);
     return state;
   }
 
@@ -189,6 +190,7 @@ public class RootWizardSection extends TwoColumnLayout<WizardForm>
     if (model.isNewversion()) {
       wizardService.newVersion(state);
     }
+    validateMandatoryFields(info, state);
     return initState(info, state);
   }
 
@@ -207,6 +209,7 @@ public class RootWizardSection extends TwoColumnLayout<WizardForm>
           wizardService.cloneItem(
               oldState, model.getItemdefUuid(), model.getTransform(), model.isCloneAttachments());
     }
+    validateMandatoryFields(info, newState);
 
     return initState(info, newState);
   }
@@ -293,5 +296,12 @@ public class RootWizardSection extends TwoColumnLayout<WizardForm>
       throw new Error("No WizardSectionInfo attribute in info");
     }
     return winfo;
+  }
+
+  void validateMandatoryFields(SectionInfo info, WizardState state) {
+    PagesSection ps = info.lookupSection(PagesSection.class);
+    wizardService
+        .getWizardPages(state)
+        .forEach(p -> wizardService.ensureInitialisedPage(info, p, ps.getReloadFunction(), true));
   }
 }


### PR DESCRIPTION
#749 

* check items' mandatory fields are filled in or not in all pages before saving
* checking runs when contribute, edit and clone an item
* failed three auto-tests (TokenLoginTest, SearchSettingsTest and AdvancedScriptControlTests) due to other reasons. So Jolse suggested me put this PR first.