### PR TITLE
Component/758 controls service

### DIFF
--- a/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/Driver.java
+++ b/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/Driver.java
@@ -177,7 +177,7 @@ public final class Driver {
 
   public ControlRepository getControlRepository() {
     if (controlRepository == null) {
-      controlRepository = new ControlRepositoryImpl(pluginService);
+      controlRepository = new ControlRepositoryImpl(pluginService, clientService);
     }
     return controlRepository;
   }

--- a/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/controls/CloudControlDefinitionImpl.java
+++ b/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/controls/CloudControlDefinitionImpl.java
@@ -16,7 +16,6 @@
 
 package com.tle.admin.controls;
 
-import com.dytech.edge.admin.wizard.editor.Editor;
 import com.dytech.edge.admin.wizard.model.Control;
 import com.dytech.edge.admin.wizard.model.CustomControlModel;
 import com.dytech.edge.wizard.beans.control.CustomControl;
@@ -68,8 +67,8 @@ public class CloudControlDefinitionImpl implements ControlDefinition {
   }
 
   @Override
-  public Editor createEditor(Control control, int type, SchemaModel schema) {
-    return new CloudControlEditor(control, type, schema);
+  public CloudControlEditor createEditor(Control control, int type, SchemaModel schema) {
+    return new CloudControlEditor(def, control, type, schema);
   }
 
   @Override

--- a/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/controls/CloudControlDefinitionImpl.java
+++ b/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/controls/CloudControlDefinitionImpl.java
@@ -1,0 +1,68 @@
+package com.tle.admin.controls;
+
+import com.dytech.edge.admin.wizard.editor.Editor;
+import com.dytech.edge.admin.wizard.model.Control;
+import com.dytech.edge.admin.wizard.model.CustomControlModel;
+import com.dytech.edge.wizard.beans.control.CustomControl;
+import com.google.common.collect.ImmutableSet;
+import com.tle.admin.controls.repository.ControlDefinition;
+import com.tle.admin.schema.SchemaModel;
+import com.tle.beans.cloudproviders.CloudControlDefinition;
+import java.util.Set;
+
+public class CloudControlDefinitionImpl implements ControlDefinition {
+
+  private final CloudControlDefinition def;
+
+  public CloudControlDefinitionImpl(CloudControlDefinition def) {
+    this.def = def;
+  }
+
+  @Override
+  public EditorFactory editorFactory() {
+    return new StandardEditorFactory();
+  }
+
+  @Override
+  public Set<String> getContexts() {
+    return ImmutableSet.of("page");
+  }
+
+  @Override
+  public String getName() {
+    return def.name();
+  }
+
+  @Override
+  public String getId() {
+    return "BLAH";
+  }
+
+  @Override
+  public boolean hasContext(String context) {
+    return false;
+  }
+
+  @Override
+  public Editor createEditor(Control control, int type, SchemaModel schema) {
+    return null;
+  }
+
+  @Override
+  public String getIcon() {
+    return def.iconUrl();
+  }
+
+  @Override
+  public Control createControlModel() {
+    return new CustomControlModel<CustomControl>(this);
+  }
+
+  @Override
+  public Object createWrappedObject() {
+
+    CustomControl customControl = new CustomControl();
+    customControl.setClassType(getId());
+    return customControl;
+  }
+}

--- a/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/controls/CloudControlEditor.java
+++ b/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/controls/CloudControlEditor.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 Apereo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tle.admin.controls;
+
+import com.dytech.edge.admin.wizard.editor.AbstractControlEditor;
+import com.dytech.edge.admin.wizard.model.Control;
+import com.dytech.edge.wizard.beans.control.CustomControl;
+import com.tle.admin.gui.i18n.I18nTextField;
+import com.tle.admin.schema.SchemaModel;
+import com.tle.common.i18n.CurrentLocale;
+import com.tle.i18n.BundleCache;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+
+public class CloudControlEditor extends AbstractControlEditor<CustomControl> {
+
+  private I18nTextField title;
+
+  public CloudControlEditor(Control control, int wizardType, SchemaModel schema) {
+    super(control, wizardType, schema);
+    setupGUI();
+  }
+
+  @Override
+  protected void saveControl() {
+    CustomControl control = getWizardControl();
+
+    control.setTitle(title.save());
+  }
+
+  @Override
+  protected void loadControl() {
+    CustomControl control = getWizardControl();
+    title.load(control.getTitle());
+  }
+
+  protected void setupGUI() {
+    addSection(defaultFields());
+  }
+
+  private JComponent defaultFields() {
+    JLabel titleLabel = new JLabel(CurrentLocale.get("wizard.controls.title")); // $NON-NLS-1$
+    title = new I18nTextField(BundleCache.getLanguages());
+    JPanel all = new JPanel();
+    all.add(titleLabel);
+    all.add(title);
+    return all;
+  }
+}

--- a/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/controls/CloudControlEditor.java
+++ b/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/controls/CloudControlEditor.java
@@ -21,6 +21,7 @@ import com.dytech.edge.admin.wizard.model.Control;
 import com.dytech.edge.wizard.beans.control.CustomControl;
 import com.tle.admin.gui.i18n.I18nTextField;
 import com.tle.admin.schema.SchemaModel;
+import com.tle.beans.cloudproviders.CloudControlDefinition;
 import com.tle.common.i18n.CurrentLocale;
 import com.tle.i18n.BundleCache;
 import javax.swing.JComponent;
@@ -30,9 +31,12 @@ import javax.swing.JPanel;
 public class CloudControlEditor extends AbstractControlEditor<CustomControl> {
 
   private I18nTextField title;
+  private final CloudControlDefinition definition;
 
-  public CloudControlEditor(Control control, int wizardType, SchemaModel schema) {
+  public CloudControlEditor(
+      CloudControlDefinition definition, Control control, int wizardType, SchemaModel schema) {
     super(control, wizardType, schema);
+    this.definition = definition;
     setupGUI();
   }
 
@@ -59,6 +63,13 @@ public class CloudControlEditor extends AbstractControlEditor<CustomControl> {
     JPanel all = new JPanel();
     all.add(titleLabel);
     all.add(title);
+    definition
+        .configDefinition()
+        .foreach(
+            d ->
+                all.add(
+                    new JLabel(
+                        d.controlType().toString() + " " + d.name() + " " + d.description())));
     return all;
   }
 }

--- a/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/controls/ControlRepositoryImpl.java
+++ b/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/controls/ControlRepositoryImpl.java
@@ -105,7 +105,7 @@ public class ControlRepositoryImpl implements ControlRepository {
   public ControlDefinition getDefinition(String id) {
     ControlDefinition definition = definitions.get(id);
     if (definition == null) {
-      throw new RuntimeException("No definition for:" + id); // $NON-NLS-1$
+      return new UnavailableControlDefinition(id);
     }
     return definition;
   }

--- a/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/controls/ControlRepositoryImpl.java
+++ b/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/controls/ControlRepositoryImpl.java
@@ -20,14 +20,14 @@ import com.dytech.common.text.NumberStringComparator;
 import com.dytech.edge.admin.wizard.model.Control;
 import com.dytech.edge.wizard.beans.FixedMetadata;
 import com.dytech.edge.wizard.beans.WizardPage;
-import com.dytech.edge.wizard.beans.control.CustomControl;
 import com.dytech.edge.wizard.beans.control.WizardControl;
-import com.google.common.base.Throwables;
 import com.tle.admin.controls.repository.ControlDefinition;
 import com.tle.admin.controls.repository.ControlRepository;
+import com.tle.beans.cloudproviders.CloudControlDefinition;
 import com.tle.beans.entity.itemdef.Wizard;
-import com.tle.common.i18n.CurrentLocale;
+import com.tle.common.applet.client.ClientService;
 import com.tle.core.plugins.PluginService;
+import com.tle.core.remoting.CloudProviderAdminService;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Graphics;
@@ -41,8 +41,6 @@ import java.util.Map;
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
 import org.java.plugin.registry.Extension;
-import org.java.plugin.registry.Extension.Parameter;
-import org.java.plugin.registry.PluginDescriptor;
 
 /** @author Nicholas Read */
 public class ControlRepositoryImpl implements ControlRepository {
@@ -63,46 +61,43 @@ public class ControlRepositoryImpl implements ControlRepository {
   private final Map<String, ImageIcon> icons = new HashMap<String, ImageIcon>();
 
   private final PluginService pluginService;
+  private final CloudProviderAdminService cloudProviders;
 
   /** Constructs a new ControlRepository. */
-  public ControlRepositoryImpl(PluginService pluginService) {
+  public ControlRepositoryImpl(PluginService pluginService, ClientService services) {
     this.pluginService = pluginService;
+    this.cloudProviders = services.getService(CloudProviderAdminService.class);
 
     for (Extension extension :
         pluginService.getConnectedExtensions(
             "com.tle.admin.controls", "control")) // $NON-NLS-1$ //$NON-NLS-2$
     {
-      final String id = extension.getParameter("id").valueAsString(); // $NON-NLS-1$
 
-      final ControlDefinition definition = new ControlDefinition();
-      definition.setExtension(extension);
-      definition.setId(id);
-      definition.setName(
-          CurrentLocale.get(extension.getParameter("name").valueAsString())); // $NON-NLS-1$
-
-      final Parameter param = extension.getParameter("factoryClass"); // $NON-NLS-1$
-      definition.setEditorFactoryClass(
-          param != null ? param.valueAsString() : StandardEditorFactory.class.getName());
-
-      for (Parameter cparam : extension.getParameters("context")) // $NON-NLS-1$
-      {
-        String context = cparam.valueAsString();
-        definition.getContexts().add(context);
-
-        List<ControlDefinition> defs = contextMap.get(context);
-        if (defs == null) {
-          defs = new ArrayList<ControlDefinition>();
-          contextMap.put(context, defs);
-        }
-        defs.add(definition);
-      }
-
-      definitions.put(id, definition);
+      final ControlDefinition definition = new PluginControlExtension(pluginService, extension);
+      registerDefinition(definition);
+    }
+    for (CloudControlDefinition ccontrol : cloudProviders.listControls()) {
+      final ControlDefinition definition = new CloudControlDefinitionImpl(ccontrol);
+      registerDefinition(definition);
     }
 
     for (List<ControlDefinition> defs : contextMap.values()) {
       Collections.sort(defs, controlSorter);
     }
+  }
+
+  private void registerDefinition(ControlDefinition definition) {
+    for (String context : definition.getContexts()) // $NON-NLS-1$
+    {
+      List<ControlDefinition> defs = contextMap.get(context);
+      if (defs == null) {
+        defs = new ArrayList<ControlDefinition>();
+        contextMap.put(context, defs);
+      }
+      defs.add(definition);
+    }
+
+    definitions.put(definition.getId(), definition);
   }
 
   /** Returns the control definition for the given ID. */
@@ -124,10 +119,8 @@ public class ControlRepositoryImpl implements ControlRepository {
     if (icon == null) {
       // Construct the icon
       ControlDefinition definition = getDefinition(id);
-      Extension extension = definition.getExtension();
-      Parameter param = extension.getParameter("icon"); // $NON-NLS-1$
-      String iconPath =
-          param != null ? param.valueAsString() : "/icons/" + DEFAULT_ICON; // $NON-NLS-1$
+      String iconDefPath = definition.getIcon(); // $NON-NLS-1$
+      String iconPath = iconDefPath != null ? iconDefPath : "/icons/" + DEFAULT_ICON; // $NON-NLS-1$
       icon = new ControlIcon(getClass().getResource(iconPath), scripted);
 
       // Put it back in to the map
@@ -172,24 +165,9 @@ public class ControlRepositoryImpl implements ControlRepository {
   @SuppressWarnings("nls")
   public Object getModelForControl(String id) {
     ControlDefinition definition = getDefinition(id);
-    Extension extension = definition.getExtension();
-    PluginDescriptor plugin = extension.getDeclaringPluginDescriptor();
-    pluginService.ensureActivated(plugin);
-    ClassLoader classLoader = pluginService.getClassLoader(plugin);
-    try {
-      Class<?> modelClass =
-          classLoader.loadClass(extension.getParameter("modelClass").valueAsString());
-      Control controlModel =
-          (Control) modelClass.getConstructor(ControlDefinition.class).newInstance(definition);
-      controlModel.setControlRepository(this);
-      return controlModel;
-    } catch (Exception e) /*
-							 * ClassNotFoundException, InstantiationException,
-							 * IllegalAccessException, IllegalArgumentException,
-							 * InvocationTargetException
-							 */ {
-      throw Throwables.propagate(e);
-    }
+    Control controlModel = definition.createControlModel();
+    controlModel.setControlRepository(this);
+    return controlModel;
   }
 
   @Override
@@ -210,19 +188,7 @@ public class ControlRepositoryImpl implements ControlRepository {
   @Override
   public Object getNewWrappedObject(String id) {
     ControlDefinition definition = getDefinition(id);
-    Extension extension = definition.getExtension();
-    Parameter modelParam = extension.getParameter("wrappedClass"); // $NON-NLS-1$
-    PluginDescriptor descriptor = extension.getDeclaringPluginDescriptor();
-    pluginService.ensureActivated(descriptor);
-    ClassLoader classLoader = pluginService.getClassLoader(descriptor);
-    try {
-      Class<?> modelClass =
-          classLoader.loadClass(
-              modelParam != null ? modelParam.valueAsString() : CustomControl.class.getName());
-      return modelClass.newInstance();
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
+    return definition.createWrappedObject();
   }
 
   @Override
@@ -232,15 +198,6 @@ public class ControlRepositoryImpl implements ControlRepository {
       return Collections.emptyList();
     }
     return defs;
-  }
-
-  @Override
-  public List<ClassLoader> getClassLoaders() {
-    List<ClassLoader> res = new ArrayList<ClassLoader>();
-    for (ControlDefinition def : definitions.values()) {
-      res.add(pluginService.getClassLoader(def.getExtension().getDeclaringPluginDescriptor()));
-    }
-    return res;
   }
 
   @SuppressWarnings("serial")

--- a/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/controls/PluginControlExtension.java
+++ b/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/controls/PluginControlExtension.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Apereo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.tle.admin.controls;
 
 import com.dytech.edge.admin.wizard.WizardHelper;

--- a/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/controls/PluginControlExtension.java
+++ b/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/controls/PluginControlExtension.java
@@ -1,0 +1,134 @@
+package com.tle.admin.controls;
+
+import com.dytech.edge.admin.wizard.WizardHelper;
+import com.dytech.edge.admin.wizard.editor.Editor;
+import com.dytech.edge.admin.wizard.model.Control;
+import com.dytech.edge.wizard.beans.control.CustomControl;
+import com.google.common.base.Throwables;
+import com.tle.admin.controls.repository.ControlDefinition;
+import com.tle.admin.schema.SchemaModel;
+import com.tle.common.i18n.CurrentLocale;
+import com.tle.core.plugins.PluginService;
+import java.lang.reflect.Constructor;
+import java.util.HashSet;
+import java.util.Set;
+import org.java.plugin.registry.Extension;
+import org.java.plugin.registry.Extension.Parameter;
+import org.java.plugin.registry.PluginDescriptor;
+
+public class PluginControlExtension implements ControlDefinition {
+
+  private final PluginService pluginService;
+  private final String id;
+  private final String nameKey;
+  private final Set<String> contexts;
+  private final Extension extension;
+
+  public PluginControlExtension(PluginService pluginService, Extension extension) {
+
+    this.pluginService = pluginService;
+    this.id = extension.getParameter("id").valueAsString();
+    this.nameKey = extension.getParameter("name").valueAsString(); // $NON-NLS-1$
+    this.extension = extension;
+
+    Set<String> contexts = new HashSet<>();
+    for (Parameter cparam : extension.getParameters("context")) // $NON-NLS-1$
+    {
+      contexts.add(cparam.valueAsString());
+    }
+    this.contexts = contexts;
+  }
+
+  @Override
+  public Set<String> getContexts() {
+    return contexts;
+  }
+
+  @Override
+  public String getName() {
+    return CurrentLocale.get(nameKey);
+  }
+
+  @Override
+  public String toString() {
+    return getName();
+  }
+
+  @Override
+  public String getId() {
+    return id;
+  }
+
+  @Override
+  public boolean hasContext(String context) {
+    return contexts.contains(context);
+  }
+
+  @Override
+  public String getIcon() {
+    Parameter param = extension.getParameter("icon");
+    return param != null ? param.valueAsString() : null;
+  }
+
+  @Override
+  public Editor createEditor(Control control, int type, SchemaModel schema) {
+    String editorClassName = extension.getParameter("editorClass").valueAsString(); // $NON-NLS-1$
+
+    try {
+      Class<?> editorClass =
+          pluginService
+              .getClassLoader(extension.getDeclaringPluginDescriptor())
+              .loadClass(editorClassName);
+      Constructor<?> cons = editorClass.getConstructor(WizardHelper.getEditorParamTypes());
+
+      // Invoke the constructor for the new editor.
+      Object[] params = {control, type, schema};
+
+      return (Editor) cons.newInstance(params);
+    } catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  @Override
+  public EditorFactory editorFactory() {
+    final Parameter param = extension.getParameter("factoryClass"); // $NON-NLS-1$
+    final String editorClass =
+        param != null ? param.valueAsString() : StandardEditorFactory.class.getName();
+    return (EditorFactory)
+        pluginService.getBean(extension.getDeclaringPluginDescriptor(), editorClass);
+  }
+
+  @Override
+  public Control createControlModel() {
+
+    PluginDescriptor plugin = extension.getDeclaringPluginDescriptor();
+    pluginService.ensureActivated(plugin);
+    ClassLoader classLoader = pluginService.getClassLoader(plugin);
+    try {
+      Class<?> modelClass =
+          classLoader.loadClass(extension.getParameter("modelClass").valueAsString());
+      Control controlModel =
+          (Control) modelClass.getConstructor(ControlDefinition.class).newInstance(this);
+      return controlModel;
+    } catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  @Override
+  public Object createWrappedObject() {
+    Parameter modelParam = extension.getParameter("wrappedClass"); // $NON-NLS-1$
+    PluginDescriptor descriptor = extension.getDeclaringPluginDescriptor();
+    pluginService.ensureActivated(descriptor);
+    ClassLoader classLoader = pluginService.getClassLoader(descriptor);
+    try {
+      Class<?> modelClass =
+          classLoader.loadClass(
+              modelParam != null ? modelParam.valueAsString() : CustomControl.class.getName());
+      return modelClass.newInstance();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/controls/StandardEditorFactory.java
+++ b/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/controls/StandardEditorFactory.java
@@ -16,15 +16,11 @@
 
 package com.tle.admin.controls;
 
-import com.dytech.edge.admin.wizard.WizardHelper;
 import com.dytech.edge.admin.wizard.editor.Editor;
 import com.dytech.edge.admin.wizard.model.Control;
-import com.google.common.base.Throwables;
 import com.tle.admin.controls.repository.ControlDefinition;
 import com.tle.admin.schema.SchemaModel;
 import com.tle.core.plugins.PluginService;
-import java.lang.reflect.Constructor;
-import org.java.plugin.registry.Extension;
 
 public class StandardEditorFactory implements EditorFactory {
 
@@ -32,23 +28,6 @@ public class StandardEditorFactory implements EditorFactory {
   public Editor getEditor(
       Control control, int type, SchemaModel schema, PluginService pluginService) {
     ControlDefinition definition = control.getDefinition();
-
-    Extension extension = definition.getExtension();
-    String editorClassName = extension.getParameter("editorClass").valueAsString(); // $NON-NLS-1$
-
-    try {
-      Class<?> editorClass =
-          pluginService
-              .getClassLoader(extension.getDeclaringPluginDescriptor())
-              .loadClass(editorClassName);
-      Constructor<?> cons = editorClass.getConstructor(WizardHelper.getEditorParamTypes());
-
-      // Invoke the constructor for the new editor.
-      Object[] params = {control, type, schema};
-
-      return (Editor) cons.newInstance(params);
-    } catch (Exception e) {
-      throw Throwables.propagate(e);
-    }
+    return definition.createEditor(control, type, schema);
   }
 }

--- a/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/controls/UnavailableControlDefinition.java
+++ b/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/controls/UnavailableControlDefinition.java
@@ -16,25 +16,21 @@
 
 package com.tle.admin.controls;
 
+import com.dytech.edge.admin.wizard.editor.AbstractControlEditor;
 import com.dytech.edge.admin.wizard.editor.Editor;
+import com.dytech.edge.admin.wizard.model.AbstractControlModel;
 import com.dytech.edge.admin.wizard.model.Control;
-import com.dytech.edge.admin.wizard.model.CustomControlModel;
-import com.dytech.edge.wizard.beans.control.CustomControl;
-import com.google.common.collect.ImmutableSet;
+import com.dytech.edge.wizard.beans.control.WizardControl;
 import com.tle.admin.controls.repository.ControlDefinition;
 import com.tle.admin.schema.SchemaModel;
-import com.tle.beans.cloudproviders.CloudControlDefinition;
 import java.util.Set;
 
-public class CloudControlDefinitionImpl implements ControlDefinition {
+public class UnavailableControlDefinition implements ControlDefinition {
 
-  private final CloudControlDefinition def;
-  private final String fullId;
-  private static final Set<String> contexts = ImmutableSet.of("page");
+  private final String id;
 
-  public CloudControlDefinitionImpl(CloudControlDefinition def) {
-    this.def = def;
-    this.fullId = "cp." + def.providerId().toString() + "." + def.controlId();
+  public UnavailableControlDefinition(String id) {
+    this.id = id;
   }
 
   @Override
@@ -44,49 +40,48 @@ public class CloudControlDefinitionImpl implements ControlDefinition {
 
   @Override
   public Set<String> getContexts() {
-    return contexts;
+    return null;
   }
 
   @Override
   public String getName() {
-    return def.name();
-  }
-
-  @Override
-  public String toString() {
-    return getName();
+    return "{" + id + "}";
   }
 
   @Override
   public String getId() {
-    return fullId;
+    return id;
   }
 
   @Override
   public boolean hasContext(String context) {
-    return getContexts().contains(context);
+    return false;
   }
 
   @Override
   public Editor createEditor(Control control, int type, SchemaModel schema) {
-    return new CloudControlEditor(control, type, schema);
+    return new AbstractControlEditor<WizardControl>(control, type, schema) {
+
+      @Override
+      protected void saveControl() {}
+
+      @Override
+      protected void loadControl() {}
+    };
   }
 
   @Override
   public String getIcon() {
-    return def.iconUrl();
+    return null;
   }
 
   @Override
   public Control createControlModel() {
-    return new CustomControlModel<CustomControl>(this);
+    return new AbstractControlModel(this) {};
   }
 
   @Override
   public Object createWrappedObject() {
-
-    CustomControl customControl = new CustomControl();
-    customControl.setClassType(getId());
-    return customControl;
+    return null;
   }
 }

--- a/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/controls/repository/ControlDefinition.java
+++ b/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/controls/repository/ControlDefinition.java
@@ -16,69 +16,29 @@
 
 package com.tle.admin.controls.repository;
 
-import java.util.HashSet;
+import com.dytech.edge.admin.wizard.editor.Editor;
+import com.dytech.edge.admin.wizard.model.Control;
+import com.tle.admin.controls.EditorFactory;
+import com.tle.admin.schema.SchemaModel;
 import java.util.Set;
-import org.java.plugin.registry.Extension;
 
 /** @author Nicholas Read */
-public class ControlDefinition {
-  private Set<String> contexts = new HashSet<String>();
+public interface ControlDefinition {
+  EditorFactory editorFactory();
 
-  private String id;
-  private String name;
-  private String editorFactoryClass;
-  private Extension extension;
+  Set<String> getContexts();
 
-  public ControlDefinition() {
-    super();
-  }
+  String getName();
 
-  public Extension getExtension() {
-    return extension;
-  }
+  String getId();
 
-  public void setExtension(Extension extension) {
-    this.extension = extension;
-  }
+  boolean hasContext(String context);
 
-  public String getId() {
-    return id;
-  }
+  Editor createEditor(Control control, int type, SchemaModel schema);
 
-  public void setId(String id) {
-    this.id = id;
-  }
+  String getIcon();
 
-  public String getName() {
-    return name;
-  }
+  Control createControlModel();
 
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  @Override
-  public String toString() {
-    return getName();
-  }
-
-  public String getEditorFactoryClass() {
-    return editorFactoryClass;
-  }
-
-  public void setEditorFactoryClass(String editorFactoryClass) {
-    this.editorFactoryClass = editorFactoryClass;
-  }
-
-  public Set<String> getContexts() {
-    return contexts;
-  }
-
-  public void setContexts(Set<String> contexts) {
-    this.contexts = contexts;
-  }
-
-  public boolean hasContext(String context) {
-    return contexts.contains(context);
-  }
+  Object createWrappedObject();
 }

--- a/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/controls/repository/ControlRepository.java
+++ b/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/controls/repository/ControlRepository.java
@@ -33,6 +33,4 @@ public interface ControlRepository {
   Icon getIcon(String id, boolean scripted);
 
   List<ControlDefinition> getDefinitionsForContext(String category);
-
-  List<ClassLoader> getClassLoaders();
 }

--- a/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/itemdefinition/WizardTab.java
+++ b/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/itemdefinition/WizardTab.java
@@ -46,7 +46,6 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.event.TreeSelectionEvent;
 import javax.swing.event.TreeSelectionListener;
-import org.java.plugin.registry.Extension;
 
 public class WizardTab extends AbstractItemdefTab
     implements ActionListener, TreeSelectionListener, ComponentListener {
@@ -202,12 +201,7 @@ public class WizardTab extends AbstractItemdefTab
             if (control != null) {
               // Get the class
               ControlDefinition definition = control.getDefinition();
-              Extension extension = definition.getExtension();
-              EditorFactory editorFactory =
-                  (EditorFactory)
-                      pluginService.getBean(
-                          extension.getDeclaringPluginDescriptor(),
-                          definition.getEditorFactoryClass());
+              EditorFactory editorFactory = definition.editorFactory();
 
               currentEditor = editorFactory.getEditor(control, wizardType, schema, pluginService);
 

--- a/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/powersearch/PowerSearchTab.java
+++ b/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/powersearch/PowerSearchTab.java
@@ -45,7 +45,6 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
-import org.java.plugin.registry.Extension;
 
 public class PowerSearchTab extends AbstractPowerSearchTab
     implements ActionListener, ListSelectionListener {
@@ -178,12 +177,7 @@ public class PowerSearchTab extends AbstractPowerSearchTab
               // Get the class
               PluginServiceImpl pluginService = Driver.instance().getPluginService();
               ControlDefinition definition = control.getDefinition();
-              Extension extension = definition.getExtension();
-              EditorFactory editorFactory =
-                  (EditorFactory)
-                      pluginService.getBean(
-                          extension.getDeclaringPluginDescriptor(),
-                          definition.getEditorFactoryClass());
+              EditorFactory editorFactory = definition.editorFactory();
 
               currentEditor =
                   editorFactory.getEditor(

--- a/Source/Plugins/Core/com.equella.base/scalasrc/com/tle/beans/cloudproviders/CloudControlDefinition.scala
+++ b/Source/Plugins/Core/com.equella.base/scalasrc/com/tle/beans/cloudproviders/CloudControlDefinition.scala
@@ -20,10 +20,14 @@ import java.util.UUID
 
 case class CloudConfigOption(name: String, value: String)
 
+object CloudControlType extends Enumeration {
+  val XPath, Textfield, Dropdown, Check, Radio = Value
+}
+
 case class CloudConfigControl(id: String,
                               name: String,
                               description: Option[String],
-                              controlType: String,
+                              controlType: CloudControlType.Value,
                               options: Iterable[CloudConfigOption],
                               min: Int,
                               max: Int)

--- a/Source/Plugins/Core/com.equella.base/scalasrc/com/tle/beans/cloudproviders/CloudControlDefinition.scala
+++ b/Source/Plugins/Core/com.equella.base/scalasrc/com/tle/beans/cloudproviders/CloudControlDefinition.scala
@@ -1,3 +1,35 @@
+/*
+ * Copyright 2017 Apereo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.tle.beans.cloudproviders
 
-case class CloudControlDefinition(name: String, iconUrl: String)
+import java.util.UUID
+
+case class CloudConfigOption(name: String, value: String)
+
+case class CloudConfigControl(id: String,
+                              name: String,
+                              description: Option[String],
+                              controlType: String,
+                              options: Iterable[CloudConfigOption],
+                              min: Int,
+                              max: Int)
+
+case class CloudControlDefinition(providerId: UUID,
+                                  controlId: String,
+                                  name: String,
+                                  iconUrl: String,
+                                  configDefinition: Iterable[CloudConfigControl])

--- a/Source/Plugins/Core/com.equella.base/scalasrc/com/tle/beans/cloudproviders/CloudControlDefinition.scala
+++ b/Source/Plugins/Core/com.equella.base/scalasrc/com/tle/beans/cloudproviders/CloudControlDefinition.scala
@@ -1,0 +1,3 @@
+package com.tle.beans.cloudproviders
+
+case class CloudControlDefinition(name: String, iconUrl: String)

--- a/Source/Plugins/Core/com.equella.base/src/com/tle/core/remoting/CloudProviderAdminService.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/core/remoting/CloudProviderAdminService.java
@@ -1,0 +1,9 @@
+package com.tle.core.remoting;
+
+import com.tle.beans.cloudproviders.CloudControlDefinition;
+import java.util.List;
+
+public interface CloudProviderAdminService {
+
+  List<CloudControlDefinition> listControls();
+}

--- a/Source/Plugins/Core/com.equella.base/src/com/tle/core/remoting/CloudProviderAdminService.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/core/remoting/CloudProviderAdminService.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Apereo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.tle.core.remoting;
 
 import com.tle.beans.cloudproviders.CloudControlDefinition;

--- a/Source/Plugins/Core/com.equella.core/plugin-jpf.xml
+++ b/Source/Plugins/Core/com.equella.core/plugin-jpf.xml
@@ -670,6 +670,10 @@
     <parameter id="class" value="com.tle.core.remoting.RemoteBaseEntityService" />
     <parameter id="bean" value="bean:remoteBaseEntityService" />
   </extension>
+  <extension plugin-id="com.tle.web.services" point-id="invoker" id="cloudProviderInvoker">
+    <parameter id="class" value="com.tle.core.remoting.CloudProviderAdminService" />
+    <parameter id="bean" value="bean:com.tle.core.remoting.CloudProviderAdminService" />
+  </extension>
   <extension plugin-id="com.tle.core.item" point-id="itemResolver" id="cloud">
     <parameter id="id" value="cloud" />
     <parameter id="bean" value="bean:com.tle.core.cloud.service.CloudService" />

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudProviderAdminServiceImpl.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudProviderAdminServiceImpl.scala
@@ -1,6 +1,23 @@
+/*
+ * Copyright 2017 Apereo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.tle.core.cloudproviders
 
 import java.util
+import java.util.UUID
 
 import com.tle.beans.cloudproviders.CloudControlDefinition
 import com.tle.core.guice.Bind
@@ -11,5 +28,10 @@ import scala.collection.JavaConverters._
 @Bind(classOf[CloudProviderAdminService])
 class CloudProviderAdminServiceImpl extends CloudProviderAdminService {
   override def listControls: util.List[CloudControlDefinition] =
-    List(CloudControlDefinition("My control", "/icons/control.gif"): CloudControlDefinition).asJava
+    List(
+      CloudControlDefinition(UUID.fromString("36dc5aaa-b0d4-462c-b6c4-67b7f2f986a3"),
+                             "sample",
+                             "My control",
+                             "/icons/control.gif",
+                             Iterable.empty): CloudControlDefinition).asJava
 }

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudProviderAdminServiceImpl.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudProviderAdminServiceImpl.scala
@@ -1,0 +1,15 @@
+package com.tle.core.cloudproviders
+
+import java.util
+
+import com.tle.beans.cloudproviders.CloudControlDefinition
+import com.tle.core.guice.Bind
+import com.tle.core.remoting.CloudProviderAdminService
+
+import scala.collection.JavaConverters._
+
+@Bind(classOf[CloudProviderAdminService])
+class CloudProviderAdminServiceImpl extends CloudProviderAdminService {
+  override def listControls: util.List[CloudControlDefinition] =
+    List(CloudControlDefinition("My control", "/icons/control.gif"): CloudControlDefinition).asJava
+}

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudProviderAdminServiceImpl.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudProviderAdminServiceImpl.scala
@@ -19,7 +19,12 @@ package com.tle.core.cloudproviders
 import java.util
 import java.util.UUID
 
-import com.tle.beans.cloudproviders.CloudControlDefinition
+import com.tle.beans.cloudproviders.{
+  CloudConfigControl,
+  CloudConfigOption,
+  CloudControlDefinition,
+  CloudControlType
+}
 import com.tle.core.guice.Bind
 import com.tle.core.remoting.CloudProviderAdminService
 
@@ -27,11 +32,54 @@ import scala.collection.JavaConverters._
 
 @Bind(classOf[CloudProviderAdminService])
 class CloudProviderAdminServiceImpl extends CloudProviderAdminService {
-  override def listControls: util.List[CloudControlDefinition] =
-    List(
-      CloudControlDefinition(UUID.fromString("36dc5aaa-b0d4-462c-b6c4-67b7f2f986a3"),
-                             "sample",
-                             "My control",
-                             "/icons/control.gif",
-                             Iterable.empty): CloudControlDefinition).asJava
+
+  val multiOptions =
+    Iterable(CloudConfigOption("First entry", "first"), CloudConfigOption("SecondEntry", "second"))
+
+  override def listControls: util.List[CloudControlDefinition] = {
+    val ctrl1 = CloudControlDefinition(
+      UUID.fromString("36dc5aaa-b0d4-462c-b6c4-67b7f2f986a3"),
+      "sample",
+      "My control",
+      "/icons/control.gif",
+      Iterable(
+        CloudConfigControl("path",
+                           "Target node",
+                           Some("Please select a target node"),
+                           CloudControlType.XPath,
+                           Iterable.empty,
+                           0,
+                           1),
+        CloudConfigControl("plaintext",
+                           "A text entry",
+                           Some("This is some text"),
+                           CloudControlType.Textfield,
+                           Iterable.empty,
+                           1,
+                           1),
+        CloudConfigControl("choice",
+                           "A drop down",
+                           Some("This is mandatory"),
+                           CloudControlType.Dropdown,
+                           multiOptions,
+                           1,
+                           1),
+        CloudConfigControl("checkbox",
+                           "Some checboxes",
+                           Some("Select some if you want"),
+                           CloudControlType.Check,
+                           multiOptions,
+                           0,
+                           Int.MaxValue),
+        CloudConfigControl("radio",
+                           "Some radioboxes",
+                           Some("Please select one of these"),
+                           CloudControlType.Radio,
+                           multiOptions,
+                           1,
+                           1)
+      )
+    )
+    List(ctrl1: CloudControlDefinition).asJava
+  }
 }


### PR DESCRIPTION
* Create a remote service which the admin console can call to get a list of cloud controls with some sample data
* Refactor admin console editor to abstract away from only allowing JPF based editors, make a stub cloud control editor