### PR TITLE
Login Notice: Remove fullpage plugin that added doctype and html tags

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/components/RichTextEditor.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/components/RichTextEditor.tsx
@@ -12,7 +12,6 @@ require("tinymce/plugins/charmap");
 require("tinymce/plugins/code");
 require("tinymce/plugins/codesample");
 require("tinymce/plugins/directionality");
-require("tinymce/plugins/fullpage");
 require("tinymce/plugins/fullscreen");
 require("tinymce/plugins/help");
 require("tinymce/plugins/hr");
@@ -93,7 +92,7 @@ class RichTextEditor extends React.Component<RichTextEditorProps> {
         }
         plugins={
           "anchor autolink autoresize advlist charmap code codesample  " +
-          "directionality fullpage fullscreen help hr image imagetools " +
+          "directionality fullscreen help hr image imagetools " +
           "importcss insertdatetime link lists media nonbreaking noneditable pagebreak paste " +
           "preview print quickbars save searchreplace table template " +
           "textpattern toc visualblocks visualchars wordcount"

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/loginnotice/LoginNoticeModule.ts
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/loginnotice/LoginNoticeModule.ts
@@ -23,16 +23,6 @@ export interface PreLoginNotice {
   endDate?: Date;
 }
 
-export const emptyTinyMCEString =
-  "<!DOCTYPE html>\n" +
-  "<html>\n" +
-  "<head>\n" +
-  "</head>\n" +
-  "<body>\n" +
-  "\n" +
-  "</body>\n" +
-  "</html>";
-
 export const strings = prepLangStrings("loginnoticepage", {
   title: "Login notice editor",
   clear: {

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/loginnotice/PreLoginNoticeConfigurator.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/loginnotice/PreLoginNoticeConfigurator.tsx
@@ -10,7 +10,6 @@ import {
 } from "@material-ui/core";
 import {
   clearPreLoginNotice,
-  emptyTinyMCEString,
   getPreLoginNotice,
   NotificationType,
   PreLoginNotice,
@@ -58,7 +57,7 @@ class PreLoginNoticeConfigurator extends React.Component<
   }
 
   handleSubmitPreNotice = () => {
-    if (this.state.current.notice == emptyTinyMCEString) {
+    if (this.state.current.notice == "") {
       clearPreLoginNotice()
         .then(() => {
           this.props.notify(NotificationType.Clear);


### PR DESCRIPTION
On IE 11, the extra `DOCTYPE, <head/>, <html/> and <body/>` tags in the login notice caused issues that prevent the login notice from rendering properly. Removing the "fullpage" plugin from TinyMCE should resolve this, as this plugin's purpose is to add the page setup tags that cause this problem.