### PR TITLE
Add MIME-type checker to FileSystemService

### DIFF
--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/services/FileSystemService.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/services/FileSystemService.java
@@ -133,6 +133,8 @@ public interface FileSystemService extends RemoteFileSystemService {
   FileInfo write(FileHandle handle, String filename, Reader content, boolean append)
       throws IOException;
 
+  String getMimeType(FileHandle fileHandle, String name) throws IOException;
+
   FileInfo getFileInfo(FileHandle handle, String filename);
 
   void saveFiles(StagingFile staging, FileHandle destination) throws IOException;

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/services/impl/FileSystemServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/services/impl/FileSystemServiceImpl.java
@@ -362,6 +362,10 @@ public class FileSystemServiceImpl implements FileSystemService, ServiceCheckReq
     return new FileInfo(byteCount, filename);
   }
 
+  public String getMimeType(FileHandle fileHandle, String name) throws IOException {
+    return Files.probeContentType(getFile(fileHandle, name).toPath());
+  }
+
   @Override
   public FileInfo getFileInfo(FileHandle handle, String filename) {
     File extFile = getFile(handle, filename);

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/settings/loginnotice/LoginNoticeService.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/settings/loginnotice/LoginNoticeService.java
@@ -30,6 +30,8 @@ public interface LoginNoticeService {
 
   String uploadPreLoginNoticeImage(InputStream imageFile, String name) throws IOException;
 
+  String getMimeType(String name) throws IOException;
+
   InputStream getPreLoginNoticeImage(String name) throws IOException;
 
   String getPostLoginNotice();

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/settings/loginnotice/impl/LoginNoticeServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/settings/loginnotice/impl/LoginNoticeServiceImpl.java
@@ -162,6 +162,15 @@ public class LoginNoticeServiceImpl implements LoginNoticeService {
   }
 
   @Override
+  public String getMimeType(String name) throws IOException {
+    CustomisationFile customisationFile = new CustomisationFile();
+    if (fileSystemService.fileExists(customisationFile, LOGIN_NOTICE_IMAGE_FOLDER_NAME + name)) {
+      return fileSystemService.getMimeType(customisationFile, name);
+    }
+    return null;
+  }
+
+  @Override
   public InputStream getPreLoginNoticeImage(String name) throws IOException {
     CustomisationFile customisationFile = new CustomisationFile();
     if (fileSystemService.fileExists(customisationFile, LOGIN_NOTICE_IMAGE_FOLDER_NAME + name)) {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/settings/loginnotice/impl/LoginNoticeServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/settings/loginnotice/impl/LoginNoticeServiceImpl.java
@@ -37,6 +37,7 @@ import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.ws.rs.BadRequestException;
+import javax.ws.rs.core.MediaType;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.StringUtils;
 import org.jsoup.Jsoup;
@@ -167,7 +168,7 @@ public class LoginNoticeServiceImpl implements LoginNoticeService {
     if (fileSystemService.fileExists(customisationFile, LOGIN_NOTICE_IMAGE_FOLDER_NAME + name)) {
       return fileSystemService.getMimeType(customisationFile, name);
     }
-    return null;
+    return MediaType.MEDIA_TYPE_WILDCARD;
   }
 
   @Override

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/api/loginnotice/impl/PreLoginNoticeResourceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/api/loginnotice/impl/PreLoginNoticeResourceImpl.java
@@ -29,7 +29,6 @@ import java.io.InputStream;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
@@ -66,7 +65,7 @@ public class PreLoginNoticeResourceImpl implements PreLoginNoticeResource {
 
   @Override
   public Response getPreLoginNoticeImage(String name) throws IOException {
-    return Response.ok(noticeService.getPreLoginNoticeImage(name), MediaType.MEDIA_TYPE_WILDCARD)
+    return Response.ok(noticeService.getPreLoginNoticeImage(name), noticeService.getMimeType(name))
         .build();
   }
 


### PR DESCRIPTION
#660 
MIME type as a wildcard was sufficient for modern browsers, but not for IE11. Added a method to get the MIME type from login notice images to fix in IE11.
![image](https://user-images.githubusercontent.com/24543345/55692762-39e66600-59ee-11e9-8c62-57a74bdbf82c.png)
