### PR TITLE
Bugfix/781 failing to edit an item

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/src/UI/LegacyContent.purs
+++ b/Source/Plugins/Core/com.equella.core/js/src/UI/LegacyContent.purs
@@ -38,6 +38,7 @@ import React.DOM as D
 import React.DOM.Props (Props, _id, _type, onSubmit)
 import React.DOM.Props as DP
 import React.SyntheticEvent (preventDefault)
+import Unsafe.Reference (unsafeRefEq)
 import Web.DOM.Document (createElement, getElementsByTagName, toNonElementParentNode)
 import Web.DOM.Element as Elem
 import Web.DOM.HTMLCollection (item, toArray)
@@ -252,7 +253,7 @@ legacyContent = unsafeCreateLeafElement $ withStyles styles $ component "LegacyC
     eval = case _ of 
       Updated oldPage -> do 
         {page} <- getProps
-        if oldPage /= page then eval LoadPage else pure unit
+        if not $ unsafeRefEq oldPage page then eval LoadPage else pure unit
       LoadPage -> do 
         {page: LegacyURI pagePath params} <- getProps 
         modifyState _ {pagePath = pagePath}

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/beans/Availability.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/beans/Availability.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Apereo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.tle.core.connectors.blackboard.beans;
 
 import javax.xml.bind.annotation.XmlRootElement;

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/beans/Content.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/beans/Content.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Apereo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.tle.core.connectors.blackboard.beans;
 
 import javax.xml.bind.annotation.XmlRootElement;

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/beans/Contents.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/beans/Contents.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Apereo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.tle.core.connectors.blackboard.beans;
 
 public class Contents extends PagedResults<Content> {}

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/beans/Course.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/beans/Course.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Apereo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.tle.core.connectors.blackboard.beans;
 
 import javax.xml.bind.annotation.XmlRootElement;

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/beans/Courses.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/beans/Courses.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Apereo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.tle.core.connectors.blackboard.beans;
 
 import javax.xml.bind.annotation.XmlRootElement;

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/beans/PagedResults.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/beans/PagedResults.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Apereo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.tle.core.connectors.blackboard.beans;
 
 import java.util.List;

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/beans/Paging.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/beans/Paging.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Apereo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.tle.core.connectors.blackboard.beans;
 
 import javax.xml.bind.annotation.XmlRootElement;

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/beans/Token.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/beans/Token.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Apereo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.tle.core.connectors.blackboard.beans;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/service/BlackboardRESTConnectorService.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/service/BlackboardRESTConnectorService.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Apereo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.tle.core.connectors.blackboard.service;
 
 import com.tle.core.connectors.service.ConnectorRepositoryImplementation;

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/service/impl/BlackboardRESTConnectorServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/connectors/blackboard/service/impl/BlackboardRESTConnectorServiceImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Apereo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.tle.core.connectors.blackboard.service.impl;
 
 import com.dytech.devlib.Base64;

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/connectors/blackboard/editor/BlackboardRESTConnectorEditor.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/connectors/blackboard/editor/BlackboardRESTConnectorEditor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Apereo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.tle.web.connectors.blackboard.editor;
 
 import com.tle.common.connectors.entity.Connector;

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/viewitem/summary/sidebar/LockedByGroupSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/viewitem/summary/sidebar/LockedByGroupSection.java
@@ -108,6 +108,7 @@ public class LockedByGroupSection
     ItemSectionInfo itemInfo = getItemInfo(info);
     itemService.forceUnlock(itemInfo.getItem());
     itemInfo.refreshItem(true);
+    info.forceRedirect();
   }
 
   public Button getUnlock() {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/command/Cancel.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/command/Cancel.java
@@ -76,7 +76,6 @@ public class Cancel extends WizardCommand {
   public void execute(SectionInfo info, WizardSectionInfo winfo, String data) throws Exception {
     final WizardState state = winfo.getWizardState();
     final boolean locked = state.isLockedForEditing();
-    info.forceRedirect();
     winfo.cancelEdit();
 
     if (moderationService.isModerating(info)) {
@@ -105,6 +104,7 @@ public class Cancel extends WizardCommand {
         }
       }
     }
+    info.forceRedirect();
   }
 
   private List<ItemDefinition> enumerateCreatable(SectionInfo info) {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/command/Cancel.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/command/Cancel.java
@@ -76,7 +76,7 @@ public class Cancel extends WizardCommand {
   public void execute(SectionInfo info, WizardSectionInfo winfo, String data) throws Exception {
     final WizardState state = winfo.getWizardState();
     final boolean locked = state.isLockedForEditing();
-
+    info.forceRedirect();
     winfo.cancelEdit();
 
     if (moderationService.isModerating(info)) {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/command/EditInWizard.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/command/EditInWizard.java
@@ -19,6 +19,8 @@ package com.tle.web.wizard.command;
 import com.tle.web.sections.SectionInfo;
 import com.tle.web.sections.equella.annotation.PlugKey;
 import com.tle.web.sections.equella.annotation.PluginResourceHandler;
+import com.tle.web.sections.events.js.JSHandler;
+import com.tle.web.sections.js.JSCallable;
 import com.tle.web.wizard.WebWizardPage;
 import com.tle.web.wizard.WizardService;
 import com.tle.web.wizard.impl.WizardCommand;
@@ -59,6 +61,13 @@ public class EditInWizard extends WizardCommand {
     for (WebWizardPage page : winfo.getWizardState().getPages()) {
       wizardService.ensureInitialisedPage(info, page, ps.getReloadFunction(), true);
     }
+    info.forceRedirect();
+  }
+
+  @Override
+  public JSHandler getJavascript(
+      SectionInfo info, WizardSectionInfo winfo, JSCallable submitFunction) {
+    return super.getJavascript(info, winfo, submitFunction);
   }
 
   @Override

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/command/EditInWizard.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/command/EditInWizard.java
@@ -19,8 +19,6 @@ package com.tle.web.wizard.command;
 import com.tle.web.sections.SectionInfo;
 import com.tle.web.sections.equella.annotation.PlugKey;
 import com.tle.web.sections.equella.annotation.PluginResourceHandler;
-import com.tle.web.sections.events.js.JSHandler;
-import com.tle.web.sections.js.JSCallable;
 import com.tle.web.wizard.WebWizardPage;
 import com.tle.web.wizard.WizardService;
 import com.tle.web.wizard.impl.WizardCommand;
@@ -62,12 +60,6 @@ public class EditInWizard extends WizardCommand {
       wizardService.ensureInitialisedPage(info, page, ps.getReloadFunction(), true);
     }
     info.forceRedirect();
-  }
-
-  @Override
-  public JSHandler getJavascript(
-      SectionInfo info, WizardSectionInfo winfo, JSCallable submitFunction) {
-    return super.getJavascript(info, winfo, submitFunction);
   }
 
   @Override

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/command/Save.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/command/Save.java
@@ -61,6 +61,7 @@ public class Save extends WizardCommand {
   public void execute(SectionInfo info, WizardSectionInfo winfo, String type) throws Exception {
     SaveDialog saveDialog = info.lookupSection(SaveDialog.class);
     saveDialog.save(info, "save", null);
+    info.forceRedirect();
   }
 
   @Override


### PR DESCRIPTION
#781 
This bugs happened when moderators click "edit resource", "cancel" and "save" when moderating an item.
All fixed now.

"info.forceredirect" doesn't work perfectly this time because the redirecting URL is as same as the current one, so REACT won't re-render UI. The solution is to do an identity comparison, to tell REACT that the redirecting URL is a different object though it has same value.