### PR TITLE
Feature/757 set permission for cloud provider

### DIFF
--- a/Source/Plugins/Core/com.equella.base/src/com/tle/common/security/PrivilegeTree.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/common/security/PrivilegeTree.java
@@ -16,6 +16,7 @@
 
 package com.tle.common.security;
 
+import static com.tle.common.security.SecurityConstants.PRIORITY_ALL_CLOUD_PROVIDER;
 import static com.tle.common.security.SecurityConstants.PRIORITY_ALL_COLLECTIONS;
 import static com.tle.common.security.SecurityConstants.PRIORITY_ALL_CONNECTORS;
 import static com.tle.common.security.SecurityConstants.PRIORITY_ALL_COURSE_INFO;
@@ -39,6 +40,7 @@ import static com.tle.common.security.SecurityConstants.PRIORITY_ALL_SYSTEM_SETT
 import static com.tle.common.security.SecurityConstants.PRIORITY_ALL_TAXONOMIES;
 import static com.tle.common.security.SecurityConstants.PRIORITY_ALL_USER_SCRIPTS;
 import static com.tle.common.security.SecurityConstants.PRIORITY_ALL_WORKFLOWS;
+import static com.tle.common.security.SecurityConstants.PRIORITY_CLOUD_PROVIDER;
 import static com.tle.common.security.SecurityConstants.PRIORITY_COLLECTION;
 import static com.tle.common.security.SecurityConstants.PRIORITY_CONNECTOR;
 import static com.tle.common.security.SecurityConstants.PRIORITY_COURSE_INFO;
@@ -163,6 +165,10 @@ public final class PrivilegeTree {
     // Sigh. Tiny MCE Plugins HAX
     ALL_HTMLEDITOR_PLUGINS(true, PRIORITY_ALL_HTMLEDITOR_PLUGINS),
     HTMLEDITOR_PLUGIN(false, PRIORITY_HTMLEDITOR_PLUGIN),
+
+    // Cloud provider
+    ALL_CLOUD_PROVIDER(true, PRIORITY_ALL_CLOUD_PROVIDER),
+    CLOUD_PROVIDER(false, PRIORITY_CLOUD_PROVIDER),
 
     ALL_HARVESTER_PROFILES(true, PRIORITY_ALL_HARVESTER_PROFILES),
     HARVESTER_PROFILE(false, PRIORITY_HARVESTER_PROFILE),
@@ -483,6 +489,12 @@ public final class PrivilegeTree {
     mapping.put(Node.ALL_SYSTEM_SETTINGS, allSystemSettings);
     allSystemSettings.registerPrivilege("EDIT_SYSTEM_SETTINGS");
     allSystemSettings.getChildren().add(systemSetting);
+
+    // Because MANAGE_CLOUD_PROVIDERS is the only one privilege needed now so there is no need to
+    // call buildBasic
+    PrivilegeNode cloudProvider = new PrivilegeNode(Node.ALL_CLOUD_PROVIDER);
+    cloudProvider.registerPrivilege("MANAGE_CLOUD_PROVIDER");
+    mapping.put(Node.ALL_CLOUD_PROVIDER, cloudProvider);
 
     // Managing activations/items/etc
     PrivilegeNode manage = new PrivilegeNode(Node.MANAGING);

--- a/Source/Plugins/Core/com.equella.base/src/com/tle/common/security/SecurityConstants.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/common/security/SecurityConstants.java
@@ -124,6 +124,8 @@ public final class SecurityConstants {
   public static final int PRIORITY_MANAGING = 350;
   public static final int PRIORITY_ALL_SYSTEM_SETTINGS = 325;
   public static final int PRIORITY_SYSTEM_SETTING = 300;
+  public static final int PRIORITY_ALL_CLOUD_PROVIDER = 250;
+  public static final int PRIORITY_CLOUD_PROVIDER = 225;
   public static final int PRIORITY_HIERARCHY_TOPIC = 200;
   public static final int PRIORITY_ITEM = 100;
   public static final int PRIORITY_OBJECT_INSTANCE = 0;

--- a/Source/Plugins/Core/com.equella.core/plugin-jpf.xml
+++ b/Source/Plugins/Core/com.equella.core/plugin-jpf.xml
@@ -1722,6 +1722,9 @@
   <extension plugin-id="com.tle.core.security" point-id="privilegeTreeProviders" id="htmleditorSettingsPrivilegeTreeProvider">
     <parameter id="provider" value="bean:com.tle.web.htmleditor.settings.HtmlEditorSettingsPrivilegeTreeProvider" />
   </extension>
+  <extension plugin-id="com.tle.core.security" point-id="privilegeTreeProviders" id="cloudProviderSettingPrivilegeTreeProvider">
+    <parameter id="provider" value="bean:com.tle.web.cloudprovider.CloudProviderSettingPrivilegeTreeProvider" />
+  </extension>
   <extension plugin-id="com.tle.web.viewitem.summary" point-id="minorAction" id="move">
     <parameter id="id" value="move" />
     <parameter id="class" value="bean:com.tle.web.cloneormove.section.MoveItemSection" />

--- a/Source/Plugins/Core/com.equella.core/resources/lang/i18n-resource-centre.properties
+++ b/Source/Plugins/Core/com.equella.core/resources/lang/i18n-resource-centre.properties
@@ -3474,6 +3474,7 @@ securitytree.googleapi=Google API
 securitytree.harvesterskipdrmsettings=Harvester skip DRM
 securitytree.htmleditorplugin=HTML editor plugin 
 securitytree.htmleditorsettings=HTML editor
+securitytree.cloudprovider=Cloud provider
 securitytree.itemadmin=Manage resources
 securitytree.languages=Language Settings
 securitytree.loggedinusers=Logged in users

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/package.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/package.scala
@@ -21,6 +21,9 @@ import java.util.UUID
 import com.tle.beans.Institution
 import com.tle.common.usermanagement.user.AbstractUserState
 import com.tle.common.usermanagement.user.valuebean.DefaultUserBean
+import com.tle.exceptions.PrivilegeRequiredException
+import com.tle.legacy.LegacyGuice
+import com.tle.web.cloudprovider.CloudProviderConstants
 
 package object cloudproviders {
 
@@ -68,5 +71,13 @@ package object cloudproviders {
 
     override def isSystem: Boolean = true
     override def getSessionID      = "PROVIDER"
+  }
+
+  def checkPermissions(): Unit = {
+    if (LegacyGuice.aclManager
+          .filterNonGrantedPrivileges(CloudProviderConstants.PRI_MANAGE_CLOUD_PROVIDER)
+          .isEmpty) {
+      throw new PrivilegeRequiredException(CloudProviderConstants.PRI_MANAGE_CLOUD_PROVIDER)
+    }
   }
 }

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/cloudprovider/CloudProviderApi.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/cloudprovider/CloudProviderApi.scala
@@ -72,6 +72,7 @@ class CloudProviderApi {
   )
   def prepareRegistration(@QueryParam("url") @DefaultValue("") providerUrl: String,
                           @Context uriInfo: UriInfo): CloudProviderForward = {
+    checkPermissions()
     UrlParser.parseUrl(providerUrl) match {
       case u: Url =>
         RunWithDB.execute {
@@ -102,6 +103,7 @@ class CloudProviderApi {
   @Path("provider/{uuid}")
   @ApiOperation(value = "Delete a cloud provider")
   def deleteRegistration(@PathParam("uuid") uuid: UUID): Response = ApiHelper.runAndBuild {
+    checkPermissions()
     CloudProviderDB.deleteRegistration(uuid).as(Response.noContent())
   }
 
@@ -109,6 +111,7 @@ class CloudProviderApi {
   @Path("")
   @ApiOperation("List current cloud providers")
   def list(): EntityPaging[CloudProviderDetails] = {
+    checkPermissions()
     RunWithDB.execute {
       ApiHelper.allEntities {
         CloudProviderDB.allProviders

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/settings/SettingsList.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/settings/SettingsList.scala
@@ -27,6 +27,7 @@ import com.tle.core.i18n.CoreStrings
 import com.tle.core.oauth.OAuthConstants
 import com.tle.core.security.AclChecks
 import com.tle.legacy.LegacyGuice._
+import com.tle.web.cloudprovider.CloudProviderConstants
 import com.tle.web.mimetypes.MimeEditorUtils
 import com.tle.web.sections.render.TextLabel
 import com.tle.web.sections.standard.model.{HtmlLinkState, SimpleBookmark}
@@ -96,7 +97,10 @@ object SettingsList {
     "cloudprovider.settings.title",
     "cloudprovider.settings.description",
     CloudProviderListPage,
-    () => !aclManager.filterNonGrantedPrivileges("EDIT_SYSTEM_SETTINGS").isEmpty
+    () =>
+      !aclManager
+        .filterNonGrantedPrivileges(CloudProviderConstants.PRI_MANAGE_CLOUD_PROVIDER)
+        .isEmpty
   )
 
   val echoSettings = CoreSettingsPage(

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/cloudprovider/CloudProviderConstants.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/cloudprovider/CloudProviderConstants.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Apereo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.tle.web.cloudprovider;
 
 public final class CloudProviderConstants {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/cloudprovider/CloudProviderConstants.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/cloudprovider/CloudProviderConstants.java
@@ -1,0 +1,5 @@
+package com.tle.web.cloudprovider;
+
+public final class CloudProviderConstants {
+  public static final String PRI_MANAGE_CLOUD_PROVIDER = "MANAGE_CLOUD_PROVIDER";
+}

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/cloudprovider/CloudProviderSettingPrivilegeTreeProvider.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/cloudprovider/CloudProviderSettingPrivilegeTreeProvider.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Apereo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.tle.web.cloudprovider;
 
 import com.tle.common.security.PrivilegeTree.Node;

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/cloudprovider/CloudProviderSettingPrivilegeTreeProvider.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/cloudprovider/CloudProviderSettingPrivilegeTreeProvider.java
@@ -1,0 +1,27 @@
+package com.tle.web.cloudprovider;
+
+import com.tle.common.security.PrivilegeTree.Node;
+import com.tle.common.security.remoting.RemotePrivilegeTreeService.SecurityTarget;
+import com.tle.common.security.remoting.RemotePrivilegeTreeService.TargetId;
+import com.tle.core.guice.Bind;
+import com.tle.core.i18n.CoreStrings;
+import com.tle.core.security.PrivilegeTreeProvider;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+@Bind
+public class CloudProviderSettingPrivilegeTreeProvider implements PrivilegeTreeProvider {
+
+  @Override
+  public void mapTargetIdsToNames(Collection<TargetId> targetIds, Map<TargetId, String> results) {}
+
+  @Override
+  public void gatherChildTargets(List<SecurityTarget> childTargets, SecurityTarget target) {
+    if (target == null) {
+      childTargets.add(
+          new SecurityTarget(
+              CoreStrings.text("securitytree.cloudprovider"), Node.ALL_CLOUD_PROVIDER, null, true));
+    }
+  }
+}


### PR DESCRIPTION
#757 
1. Add a new privilege called MANAGE_CLOUD_PROVIDER
2. Add a new node under the privilege tree to grant/revoke this privillege 
3. Accessing the page of cloud provider without this privilege will result in the list of cloud providers not displayed.
4. The add/delete buttons on cloud provider page will not work if users do not have this privilege.
![Screenshot from 2019-04-16 16-14-45](https://user-images.githubusercontent.com/47203811/56186457-c46c3c80-6062-11e9-8af2-3f0992eab46d.png)

