### PR TITLE
Validate node picker if it is mandatory

### DIFF
--- a/Source/Plugins/Core/com.equella.admin/resources/lang/i18n-admin-console.properties
+++ b/Source/Plugins/Core/com.equella.admin/resources/lang/i18n-admin-console.properties
@@ -689,5 +689,5 @@ searchmanagement.title = Remote Repository Editor
 searchmanagement.name = Remote Repository
 cloudcontrol.validation.message= {0} is mandatory
 cloudcontrol.unknownconfig.message=Unknown config type {0}
-cloudcontrol.required= *
+cloudcontrol.required=\ \ *
 cloudcontrol.title=Title

--- a/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/controls/cloudcontrol/CloudControlModel.java
+++ b/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/controls/cloudcontrol/CloudControlModel.java
@@ -20,8 +20,10 @@ import com.dytech.edge.admin.wizard.model.CustomControlModel;
 import com.tle.admin.controls.CloudControlDefinitionImpl;
 import com.tle.admin.i18n.Lookup;
 import com.tle.beans.cloudproviders.CloudControlConfig;
+import com.tle.beans.cloudproviders.CloudControlConfigType;
 import com.tle.common.applet.client.ClientService;
 import com.tle.common.wizard.controls.cloud.CloudControl;
+import java.util.List;
 
 public class CloudControlModel extends CustomControlModel<CloudControl> {
   private CloudControlDefinitionImpl definition;
@@ -41,7 +43,10 @@ public class CloudControlModel extends CustomControlModel<CloudControl> {
     for (CloudControlConfig c : definition.getDef().getConfigDefinition()) {
       if (c.isConfigMandatory()) {
         Object value = cloudControl.getAttributes().get(c.id());
-        if (value == null || value.toString().isEmpty()) {
+        if (value == null
+            || value.toString().isEmpty()
+            || (c.configType() == CloudControlConfigType.XPath()
+                && ((List<?>) value).size() == 0)) {
           return Lookup.lookup.text("cloudcontrol.validation.message", c.name());
         }
       }


### PR DESCRIPTION
#758 

* Fix the bug that a node picker is not correctly validated if it is mandatory.
* Put two spaces between the label text of a config and a asterisk if this config is mandatory.