### PR TITLE
Fix gathering metadata pointing to wrong filepath

### DIFF
--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/controls/universal/handlers/fileupload/StandardFileCreate.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/controls/universal/handlers/fileupload/StandardFileCreate.scala
@@ -29,7 +29,7 @@ object StandardFileCreate {
       fa.setDescription(uploaded.description)
       fa.setMd5sum(uploaded.fileInfo.getMd5CheckSum)
       fa.setSize(uploaded.fileInfo.getLength)
-      stg.gatherAdditionalMetadata(uploaded.originalFilename).foreach { a =>
+      stg.gatherAdditionalMetadata(uploaded.uploadPath).foreach { a =>
         fa.setData(a._1, a._2)
       }
       fa


### PR DESCRIPTION
When gathering metadata upon staging a file, the path is incorrect. This
causes tika to be unable to detect metadata.

Bug detected upon failure of WizardFileUploadProperties test.