### PR TITLE
Feature/757 display message when cloud control unavailable

### DIFF
--- a/Source/Plugins/Core/com.equella.admin/resources/lang/i18n-admin-console.properties
+++ b/Source/Plugins/Core/com.equella.admin/resources/lang/i18n-admin-console.properties
@@ -691,3 +691,4 @@ cloudcontrol.validation.message= {0} is mandatory
 cloudcontrol.unknownconfig.message=Unknown config type {0}
 cloudcontrol.required= *
 cloudcontrol.title=Title
+unavailablecontrol.message=<html>This wizard control can no longer be used.<br>Reason: The associated Cloud provider is no longer available.</html>

--- a/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/controls/UnavailableControlDefinition.java
+++ b/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/controls/UnavailableControlDefinition.java
@@ -16,11 +16,9 @@
 
 package com.tle.admin.controls;
 
-import com.dytech.edge.admin.wizard.editor.AbstractControlEditor;
 import com.dytech.edge.admin.wizard.editor.Editor;
 import com.dytech.edge.admin.wizard.model.AbstractControlModel;
 import com.dytech.edge.admin.wizard.model.Control;
-import com.dytech.edge.wizard.beans.control.WizardControl;
 import com.tle.admin.controls.repository.ControlDefinition;
 import com.tle.admin.schema.SchemaModel;
 import java.util.Set;
@@ -60,14 +58,7 @@ public class UnavailableControlDefinition implements ControlDefinition {
 
   @Override
   public Editor createEditor(Control control, int type, SchemaModel schema) {
-    return new AbstractControlEditor<WizardControl>(control, type, schema) {
-
-      @Override
-      protected void saveControl() {}
-
-      @Override
-      protected void loadControl() {}
-    };
+    return new UnavailableControlEditor(control, type, schema);
   }
 
   @Override

--- a/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/controls/UnavailableControlEditor.java
+++ b/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/controls/UnavailableControlEditor.java
@@ -19,9 +19,9 @@ package com.tle.admin.controls;
 import com.dytech.edge.admin.wizard.editor.AbstractControlEditor;
 import com.dytech.edge.admin.wizard.model.Control;
 import com.dytech.edge.wizard.beans.control.WizardControl;
+import com.tle.admin.i18n.Lookup;
 import com.tle.admin.schema.SchemaModel;
-import java.awt.BorderLayout;
-import java.awt.Color;
+import java.awt.FlowLayout;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 
@@ -29,7 +29,10 @@ public class UnavailableControlEditor extends AbstractControlEditor<WizardContro
 
   public UnavailableControlEditor(Control control, int wizardType, SchemaModel schema) {
     super(control, wizardType, schema);
-    setupGUI();
+    // if this UnavailableControl was originally a CloudControl then display an error message
+    if (control.getDefinition().getId().startsWith("cp.")) {
+      setupGUI();
+    }
   }
 
   @Override
@@ -39,10 +42,9 @@ public class UnavailableControlEditor extends AbstractControlEditor<WizardContro
   protected void loadControl() {}
 
   private void setupGUI() {
-    JPanel body = new JPanel(new BorderLayout());
-    JLabel text = new JLabel("This control is not avaliable now.");
-    text.setForeground(Color.RED);
-    body.add(text, BorderLayout.WEST);
+    JPanel body = new JPanel(new FlowLayout(FlowLayout.LEFT));
+    JLabel text = new JLabel(Lookup.lookup.text("unavailablecontrol.message"));
+    body.add(text);
     addSection(body);
   }
 }

--- a/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/controls/UnavailableControlEditor.java
+++ b/Source/Plugins/Core/com.equella.admin/src/com/tle/admin/controls/UnavailableControlEditor.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 Apereo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tle.admin.controls;
+
+import com.dytech.edge.admin.wizard.editor.AbstractControlEditor;
+import com.dytech.edge.admin.wizard.model.Control;
+import com.dytech.edge.wizard.beans.control.WizardControl;
+import com.tle.admin.schema.SchemaModel;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+
+public class UnavailableControlEditor extends AbstractControlEditor<WizardControl> {
+
+  public UnavailableControlEditor(Control control, int wizardType, SchemaModel schema) {
+    super(control, wizardType, schema);
+    setupGUI();
+  }
+
+  @Override
+  protected void saveControl() {}
+
+  @Override
+  protected void loadControl() {}
+
+  private void setupGUI() {
+    JPanel body = new JPanel(new BorderLayout());
+    JLabel text = new JLabel("This control is not avaliable now.");
+    text.setForeground(Color.RED);
+    body.add(text, BorderLayout.WEST);
+    addSection(body);
+  }
+}


### PR DESCRIPTION
Create a new UnavailableControlEditor which displays an error message if the UnavailableControl was originally a CloudControl; otherwise display nothing.