### PR TITLE
Make inline file uploads stay in sync with cloud control state

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/package.json
+++ b/Source/Plugins/Core/com.equella.core/js/package.json
@@ -13,7 +13,7 @@
     "clean": "rm -rf target/ output/ node_modules/ bower_components/",
     "dev": "pulp build && cross-env-shell parcel watch --no-autoinstall --public-url=./reactjs/ --out-dir=${npm_package_config_devjs} entrydev/*.html entrydev/scripts/*.js",
     "dev:build": "run-s bundleps && cross-env-shell parcel build --public-url=./reactjs/ --out-dir=${npm_package_config_devjs} entrybuild/*.html entrybuild/scripts/*.js",
-    "dev:uploadlist": "cross-env-shell parcel build --out-dir=${npm_package_config_devjs} entrybuild/scripts/uploadlist.js",
+    "dev:uploadlist": "run-s bundleps:uploadlist && cross-env-shell parcel build --out-dir=${npm_package_config_devjs} entrybuild/scripts/uploadlist.js",
     "build": "npm-run-all build:*",
     "build:bundles": "run-s bundleps && cross-env-shell parcel build --public-url=./reactjs/ --out-dir=${npm_package_config_dist} entrybuild/*.html entrybuild/scripts/*.js",
     "build:langbundle": "cross-env-shell parcel build target/genlang.js --no-minify --no-source-maps --target node --out-dir=target/tools && cross-env-shell \"node target/tools/genlang.js > ${npm_package_config_buildlang}/jsbundle.json\"",

--- a/Source/Plugins/Core/com.equella.core/js/src/Uploads/UploadList.purs
+++ b/Source/Plugins/Core/com.equella.core/js/src/Uploads/UploadList.purs
@@ -62,14 +62,15 @@ type InlineProps = (
     onAdd :: Effect Unit,
     editable :: Boolean,
     commandUrl :: URL,
-    strings :: ControlStrings
+    strings :: ControlStrings,
+    reloadState :: Effect Unit
 )
 
 inlineUploadClass :: ReactClass {|InlineProps}
 inlineUploadClass = component "InlineUpload" $ \this -> do 
   props@{commandUrl,ctrlId,strings} <- R.getProps this
   let 
-    d = commandEval {commandUrl,updateUI:Nothing} >>> affAction this
+    d = commandEval {commandUrl,updateUI:Just props.reloadState} >>> affAction this
     maxAttach = toMaybe props.maxAttachments
 
     componentDidUpdate _ {entries:oldEntries} _ = do

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/controls/universal/UniversalWebControlNew.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/controls/universal/UniversalWebControlNew.scala
@@ -30,6 +30,7 @@ import com.tle.core.mimetypes.MimeTypeService
 import com.tle.core.services.FileSystemService
 import com.tle.core.workflow.thumbnail.service.ThumbnailService
 import com.tle.core.workflow.video.VideoService
+import com.tle.web.cloudproviders.CloudWizardControl
 import com.tle.web.controls.universal.UniversalWebControlNew._
 import com.tle.web.controls.universal.handlers.FileUploadHandlerNew
 import com.tle.web.controls.universal.handlers.fileupload.WebFileUploads.{
@@ -215,6 +216,8 @@ class UniversalWebControlNew extends AbstractWebControl[UniversalWebControlModel
             "toomany",
             CurrentLocale.getFormatForKey("wizard.controls.file.toomanyattachments")
           ),
+          "reloadState",
+          CloudWizardControl.reloadState,
           "dialog",
           PartiallyApply.partial(dialog.getOpenFunction, 2),
           "commandUrl",


### PR DESCRIPTION
* Use an API for getting the wizard state instead of having it come from inline page scripts
* Ensure that inline file uploads trigger re-syncing of the item state
